### PR TITLE
modbus: add user data for adu callback

### DIFF
--- a/include/zephyr/modbus/modbus.h
+++ b/include/zephyr/modbus/modbus.h
@@ -377,10 +377,12 @@ int modbus_iface_get_by_name(const char *iface_name);
  *
  * @param iface      Modbus RTU interface index
  * @param adu        Pointer to the RAW ADU struct to send
+ * @param user_data  Pointer to the user data
  *
  * @retval           0 If transfer was successful
  */
-typedef int (*modbus_raw_cb_t)(const int iface, const struct modbus_adu *adu);
+typedef int (*modbus_raw_cb_t)(const int iface, const struct modbus_adu *adu,
+				void *user_data);
 
 /**
  * @brief Modbus interface mode
@@ -425,6 +427,11 @@ struct modbus_server_param {
 	uint8_t unit_id;
 };
 
+struct modbus_raw_cb {
+	modbus_raw_cb_t raw_tx_cb;
+	void *user_data;
+};
+
 /**
  * @brief User parameter structure to configure Modbus interface
  *        as client or server.
@@ -443,7 +450,7 @@ struct modbus_iface_param {
 		/** Serial support parameter of the interface */
 		struct modbus_serial_param serial;
 		/** Pointer to raw ADU callback function */
-		modbus_raw_cb_t raw_tx_cb;
+		struct modbus_raw_cb rawcb;
 	};
 };
 

--- a/samples/subsys/modbus/tcp_server/src/main.c
+++ b/samples/subsys/modbus/tcp_server/src/main.c
@@ -123,7 +123,8 @@ static struct modbus_adu tmp_adu;
 K_SEM_DEFINE(received, 0, 1);
 static int server_iface;
 
-static int server_raw_cb(const int iface, const struct modbus_adu *adu)
+static int server_raw_cb(const int iface, const struct modbus_adu *adu,
+			void *user_data)
 {
 	LOG_DBG("Server raw callback from interface %d", iface);
 
@@ -147,7 +148,8 @@ const static struct modbus_iface_param server_param = {
 		.user_cb = &mbs_cbs,
 		.unit_id = 1,
 	},
-	.raw_tx_cb = server_raw_cb,
+	.rawcb.raw_tx_cb = server_raw_cb,
+	.rawcb.user_data = NULL
 };
 
 static int init_modbus_server(void)

--- a/subsys/modbus/modbus_core.c
+++ b/subsys/modbus/modbus_core.c
@@ -53,7 +53,7 @@ static struct modbus_serial_config modbus_serial_cfg[] = {
 
 #define DEFINE_MODBUS_RAW_ADU(x, _) {				\
 		.iface_name = "RAW_"#x,				\
-		.raw_tx_cb = NULL,				\
+		.rawcb.raw_tx_cb = NULL,				\
 		.mode = MODBUS_MODE_RAW,			\
 	}
 

--- a/subsys/modbus/modbus_internal.h
+++ b/subsys/modbus/modbus_internal.h
@@ -108,7 +108,7 @@ struct modbus_context {
 		/* Serial line configuration */
 		struct modbus_serial_config *cfg;
 		/* RAW TX callback */
-		modbus_raw_cb_t raw_tx_cb;
+		struct modbus_raw_cb rawcb;
 	};
 	/* MODBUS mode */
 	enum modbus_mode mode;

--- a/subsys/modbus/modbus_raw.c
+++ b/subsys/modbus/modbus_raw.c
@@ -43,7 +43,7 @@ int modbus_raw_tx_adu(struct modbus_context *ctx)
 		return -ENODEV;
 	}
 
-	ctx->raw_tx_cb(iface, &ctx->tx_adu);
+	ctx->rawcb.raw_tx_cb(iface, &ctx->tx_adu, ctx->rawcb.user_data);
 
 	return 0;
 }
@@ -172,7 +172,8 @@ int modbus_raw_init(struct modbus_context *ctx,
 		return -ENOTSUP;
 	}
 
-	ctx->raw_tx_cb = param.raw_tx_cb;
+	ctx->rawcb.raw_tx_cb = param.rawcb.raw_tx_cb;
+	ctx->rawcb.user_data = param.rawcb.user_data;
 
 	return 0;
 }

--- a/tests/subsys/modbus/src/test_modbus.h
+++ b/tests/subsys/modbus/src/test_modbus.h
@@ -47,7 +47,9 @@ void test_holding_reg(void);
 void test_diagnostic(void);
 void test_client_disable(void);
 
-int client_raw_cb(const int iface, const struct modbus_adu *adu);
-int server_raw_cb(const int iface, const struct modbus_adu *adu);
+int client_raw_cb(const int iface, const struct modbus_adu *adu,
+		void *user_data);
+int server_raw_cb(const int iface, const struct modbus_adu *adu,
+		void *user_data);
 
 #endif /* __TEST_MODBUS_H__ */

--- a/tests/subsys/modbus/src/test_modbus_client.c
+++ b/tests/subsys/modbus/src/test_modbus_client.c
@@ -289,7 +289,8 @@ void test_client_setup_raw(void)
 
 	client_iface = modbus_iface_get_by_name(iface_name);
 	client_param.mode = MODBUS_MODE_RAW;
-	client_param.raw_tx_cb = client_raw_cb;
+	client_param.rawcb.raw_tx_cb = client_raw_cb;
+	client_param.rawcb.user_data = NULL;
 
 	err = modbus_init_client(client_iface, client_param);
 	zassert_equal(err, 0, "Failed to configure RAW client");

--- a/tests/subsys/modbus/src/test_modbus_raw.c
+++ b/tests/subsys/modbus/src/test_modbus_raw.c
@@ -16,7 +16,8 @@ K_SEM_DEFINE(received, 0, 1);
  * Server wants to send the data back.
  * We just store them in between and pass them to the client.
  */
-int server_raw_cb(const int iface, const struct modbus_adu *adu)
+int server_raw_cb(const int iface, const struct modbus_adu *adu,
+		void *user_data)
 {
 	LOG_DBG("Server raw callback from interface %d", iface);
 
@@ -38,7 +39,8 @@ int server_raw_cb(const int iface, const struct modbus_adu *adu)
  * Client wants to send the data via whatever.
  * We just store it in between and submit to the server.
  */
-int client_raw_cb(const int iface, const struct modbus_adu *adu)
+int client_raw_cb(const int iface, const struct modbus_adu *adu,
+		void *user_data)
 {
 	uint8_t server_iface = test_get_server_iface();
 	uint8_t client_iface = test_get_client_iface();

--- a/tests/subsys/modbus/src/test_modbus_server.c
+++ b/tests/subsys/modbus/src/test_modbus_server.c
@@ -271,7 +271,7 @@ void test_server_setup_raw(void)
 
 	server_iface = modbus_iface_get_by_name(iface_name);
 	server_param.mode = MODBUS_MODE_RAW;
-	server_param.raw_tx_cb = server_raw_cb;
+	server_param.rawcb.raw_tx_cb = server_raw_cb;
 
 	if (IS_ENABLED(CONFIG_MODBUS_SERVER)) {
 		err = modbus_init_server(server_iface, server_param);


### PR DESCRIPTION
add user data for adu callback, which helps in passing
socket and relevant application parameters.

Signed-off-by: Parthiban Nallathambi <parthiban@linumiz.com>