### PR TITLE
drivers: sensor: grow_r502a: Add Missing functionalities that R502a provides

### DIFF
--- a/drivers/sensor/grow_r502a/Kconfig
+++ b/drivers/sensor/grow_r502a/Kconfig
@@ -13,6 +13,12 @@ menuconfig GROW_R502A
 
 if GROW_R502A
 
+config GROW_R502A_DATA_PKT_SIZE
+	int "Template data packet size"
+	default 128
+	help
+	  Template data packet size for upload and download
+	  to the sensor device.
 choice
 	prompt "Trigger mode"
 	default GROW_R502A_TRIGGER_NONE

--- a/drivers/sensor/grow_r502a/grow_r502a.c
+++ b/drivers/sensor/grow_r502a/grow_r502a.c
@@ -441,7 +441,7 @@ static int fps_empty_db(const struct device *dev)
 
 unlock:
 	k_mutex_unlock(&drv_data->lock);
-	return 0;
+	return ret;
 }
 
 static int fps_search(const struct device *dev, uint8_t char_buf_idx)
@@ -485,6 +485,7 @@ static int fps_search(const struct device *dev, uint8_t char_buf_idx)
 		led_ctrl.cycle = 0x02;
 		fps_led_control(dev, &led_ctrl);
 		LOG_ERR("Did not find a match");
+		return -ENOENT;
 	} else {
 		led_ctrl.ctrl_code = LED_CTRL_ON_ALWAYS;
 		led_ctrl.color_idx = LED_COLOR_RED;

--- a/drivers/sensor/grow_r502a/grow_r502a.c
+++ b/drivers/sensor/grow_r502a/grow_r502a.c
@@ -217,7 +217,7 @@ static void uart_cb_handler(const struct device *uart_dev, void *user_data)
 	}
 }
 
-static int fps_led_control(const struct device *dev, struct led_params *led_control)
+static int fps_led_control(const struct device *dev, struct r502a_led_params *led_control)
 {
 	struct grow_r502a_data *drv_data = dev->data;
 	uint8_t rx_buf;
@@ -425,7 +425,7 @@ static int fps_get_image(const struct device *dev)
 	uint8_t rx_buf;
 	char const get_img_len = 1;
 
-	struct led_params led_ctrl = {
+	struct r502a_led_params led_ctrl = {
 		.ctrl_code = LED_CTRL_BREATHING,
 		.color_idx = LED_COLOR_BLUE,
 		.speed = LED_SPEED_HALF,
@@ -505,7 +505,7 @@ static int fps_store_model(const struct device *dev, uint16_t id)
 	uint8_t rx_buf;
 	char const store_model_len = 4;
 
-	struct led_params led_ctrl = {
+	struct r502a_led_params led_ctrl = {
 		.ctrl_code = LED_CTRL_BREATHING,
 		.color_idx = LED_COLOR_BLUE,
 		.speed = LED_SPEED_HALF,
@@ -595,7 +595,7 @@ static int fps_search(const struct device *dev, uint8_t char_buf_idx)
 	uint8_t rx_buf[5] = {0};
 	char const search_len = 6;
 
-	struct led_params led_ctrl = {
+	struct r502a_led_params led_ctrl = {
 		.ctrl_code = LED_CTRL_BREATHING,
 		.color_idx = LED_COLOR_BLUE,
 		.speed = LED_SPEED_HALF,
@@ -827,7 +827,7 @@ static int fps_init(const struct device *dev)
 	struct grow_r502a_data *drv_data = dev->data;
 	int ret;
 
-	struct led_params led_ctrl = {
+	struct r502a_led_params led_ctrl = {
 		.ctrl_code = LED_CTRL_FLASHING,
 		.color_idx = LED_COLOR_PURPLE,
 		.speed = LED_SPEED_HALF,
@@ -898,6 +898,14 @@ static int grow_r502a_attr_set(const struct device *dev, enum sensor_channel cha
 		return fps_store_model(dev, val->val1);
 	case SENSOR_ATTR_R502A_CAPTURE:
 		return fps_capture(dev, val->val1);
+	case SENSOR_ATTR_R502A_DEVICE_LED:
+		struct r502a_led_params led_ctrl = {
+			.ctrl_code = val[0].val1,
+			.color_idx = val[0].val2,
+			.speed = val[1].val1,
+			.cycle = val[1].val2,
+		};
+		return fps_led_control(dev, &led_ctrl);
 	default:
 		LOG_ERR("Sensor attribute not supported");
 		return -ENOTSUP;

--- a/drivers/sensor/grow_r502a/grow_r502a.h
+++ b/drivers/sensor/grow_r502a/grow_r502a.h
@@ -137,27 +137,6 @@
 
 #define R502A_COMMON_ACK_LEN 12
 
-#define LED_CTRL_BREATHING 0x01
-#define LED_CTRL_FLASHING 0x02
-#define LED_CTRL_ON_ALWAYS 0x03
-#define LED_CTRL_OFF_ALWAYS 0x04
-#define LED_CTRL_ON_GRADUALLY 0x05
-#define LED_CTRL_OFF_GRADUALLY 0x06
-
-#define LED_SPEED_HALF 0x50
-#define LED_SPEED_FULL 0xFF
-
-#define LED_COLOR_RED 0x01
-#define LED_COLOR_BLUE 0x02
-#define LED_COLOR_PURPLE 0x03
-
-struct led_params {
-	uint8_t ctrl_code;
-	uint8_t color_idx;
-	uint8_t speed; /* Speed 0x00-0xff */
-	uint8_t cycle; /* Number of cycles | 0-infinite, 1-255 */
-};
-
 union r502a_packet {
 	struct {
 		uint16_t start;

--- a/drivers/sensor/grow_r502a/grow_r502a.h
+++ b/drivers/sensor/grow_r502a/grow_r502a.h
@@ -105,8 +105,8 @@
 #define R502A_STARTCODE_IDX 0
 #define R502A_ADDRESS_IDX 2
 #define R502A_PID_IDX 6 /* Package identifier index*/
-#define R502A_PKG_LEN_IDX 7
-#define R502A_CC_IDX 9 /* Confirmation code index*/
+#define R502A_PKG_LEN_IDX 8
+#define R502A_CC_IDX 0 /* Confirmation code index*/
 
 #define R502A_STARTCODE_LEN 2
 #define R502A_ADDRESS_LEN 4
@@ -116,16 +116,26 @@
 
 #define R502A_CHAR_BUF_1 1
 #define R502A_CHAR_BUF_2 2
+#define R502A_CHAR_BUF_TOTAL 2
+
 #define R502A_CHAR_BUF_SIZE 384 /* Maximum size of characteristic value buffer*/
 #define R502A_TEMPLATE_SIZE 768 /* Maximum size of template, twice of CHAR_BUF*/
-#define R502A_MAX_BUF_SIZE 779 /*sum of checksum, header and template sizes*/
-#define R502A_BUF_SIZE 64
+
+#define R502A_TEMPLATE_MAX_SIZE (R502A_CHAR_BUF_TOTAL * R502A_TEMPLATE_SIZE)
+
+#define R502A_DATA_PKT_RECV_COUNT (R502A_TEMPLATE_MAX_SIZE / CONFIG_GROW_R502A_DATA_PKT_SIZE)
+#define R502A_DATA_PKT_SZ (CONFIG_GROW_R502A_DATA_PKT_SIZE + R502A_HEADER_LEN + R502A_CHECKSUM_LEN)
+
+#define R502A_MAX_BUF_SIZE  ((R502A_DATA_PKT_SZ * R502A_DATA_PKT_RECV_COUNT) + R502A_COMMON_ACK_LEN)
+
 #define R502A_TEMPLATES_PER_PAGE 256
 #define R502A_TEMP_TABLE_BUF_SIZE 32
 #define R502A_DELETE_COUNT_OFFSET 1
 
 #define R502A_DELAY 200
 #define R502A_RETRY_DELAY 5
+
+#define R502A_COMMON_ACK_LEN 12
 
 #define LED_CTRL_BREATHING 0x01
 #define LED_CTRL_FLASHING 0x02
@@ -150,14 +160,14 @@ struct led_params {
 
 union r502a_packet {
 	struct {
-		uint8_t	start[R502A_STARTCODE_LEN];
-		uint8_t	addr[R502A_ADDRESS_LEN];
+		uint16_t start;
+		uint32_t addr;
 		uint8_t	pid;
-		uint8_t	len[R502A_PKG_LEN];
-		uint8_t data[R502A_BUF_SIZE];
-	};
+		uint16_t len;
+		uint8_t data[CONFIG_GROW_R502A_DATA_PKT_SIZE];
+	} __packed;
 
-	uint8_t buf[R502A_BUF_SIZE];
+	uint8_t buf[R502A_DATA_PKT_SZ];
 };
 
 struct r502a_buf {
@@ -182,7 +192,12 @@ struct grow_r502a_data {
 #endif /* CONFIG_GROW_R502A_TRIGGER */
 
 	struct r502a_buf tx_buf;
-	struct r502a_buf rx_buf;
+
+	struct r502a_buf rx_data_buf;
+	union r502a_packet rx_hdr_pkt;
+	int rx_len;
+	bool rx_header;
+	bool returns_data_pkt;
 
 	struct k_mutex lock;
 	struct k_sem uart_rx_sem;

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -28,6 +28,19 @@ extern "C" {
 #endif
 
 /**
+ * @brief Representation of a sensor readout value extended
+ *
+ * To hold value of more than 8 bytes from the sensor
+ *
+ */
+struct sensor_value_ex {
+	/** @brief Pointer to value buffer. */
+	uint8_t *data;
+	/** @brief length of value buffer. */
+	size_t len;
+};
+
+/**
  * @brief Representation of a sensor readout value.
  *
  * The value is represented as having an integer and a fractional part,
@@ -45,6 +58,8 @@ struct sensor_value {
 	int32_t val1;
 	/** Fractional part of the value (in one-millionth parts). */
 	int32_t val2;
+	/** buffer part of the value*/
+	struct sensor_value_ex *ex;
 };
 
 /**

--- a/include/zephyr/drivers/sensor/grow_r502a.h
+++ b/include/zephyr/drivers/sensor/grow_r502a.h
@@ -31,11 +31,48 @@ extern "C" {
 #define LED_COLOR_BLUE 0x02
 #define LED_COLOR_PURPLE 0x03
 
+#define R502A_BAUD_9600 1
+#define R502A_BAUD_19200 2
+#define R502A_BAUD_38400 4
+#define R502A_BAUD_57600 6
+#define R502A_BAUD_115200 12
+
 struct r502a_led_params {
 	uint8_t ctrl_code;
 	uint8_t color_idx;
 	uint8_t speed; /* Speed 0x00-0xff */
 	uint8_t cycle; /* Number of cycles | 0-infinite, 1-255 */
+};
+
+enum r502a_sec_level {
+	R502A_SEC_LEVEL_1 = 1,
+	R502A_SEC_LEVEL_2,
+	R502A_SEC_LEVEL_3,
+	R502A_SEC_LEVEL_4,
+	R502A_SEC_LEVEL_5
+};
+
+enum r502a_data_len {
+	R502A_PKG_LEN_32,
+	R502A_PKG_LEN_64,
+	R502A_PKG_LEN_128,
+	R502A_PKG_LEN_256
+};
+
+enum r502a_sys_param_set {
+	R502A_BAUD_RATE = 4,
+	R502A_SECURITY_LEVEL,
+	R502A_DATA_PKG_LEN
+};
+
+struct r502a_sys_param {
+	uint16_t status_reg;
+	uint16_t system_id;
+	uint16_t lib_size;
+	uint16_t sec_level;
+	uint32_t addr;
+	uint16_t data_pkt_size;
+	uint32_t baud;
 };
 
 enum sensor_channel_grow_r502a {
@@ -73,6 +110,8 @@ enum sensor_attribute_grow_r502a {
 	SENSOR_ATTR_R502A_COMPARE,
 	/** To control device LED */
 	SENSOR_ATTR_R502A_DEVICE_LED,
+	/** To read and write device's system parameters */
+	SENSOR_ATTR_R502A_SYS_PARAM,
 };
 
 #ifdef __cplusplus

--- a/include/zephyr/drivers/sensor/grow_r502a.h
+++ b/include/zephyr/drivers/sensor/grow_r502a.h
@@ -34,6 +34,10 @@ enum sensor_attribute_grow_r502a {
 	SENSOR_ATTR_R502A_RECORD_FREE_IDX,
 	/** To empty the storage record*/
 	SENSOR_ATTR_R502A_RECORD_EMPTY,
+	/** To upload template data out of sensor */
+	SENSOR_ATTR_R502A_UPLOAD,
+	/** To download template data into the sensor */
+	SENSOR_ATTR_R502A_DOWNLOAD,
 };
 
 #ifdef __cplusplus

--- a/include/zephyr/drivers/sensor/grow_r502a.h
+++ b/include/zephyr/drivers/sensor/grow_r502a.h
@@ -13,6 +13,31 @@ extern "C" {
 
 #include <zephyr/drivers/sensor.h>
 
+/*LED glow control code*/
+#define LED_CTRL_BREATHING 0x01
+#define LED_CTRL_FLASHING 0x02
+#define LED_CTRL_ON_ALWAYS 0x03
+#define LED_CTRL_OFF_ALWAYS 0x04
+#define LED_CTRL_ON_GRADUALLY 0x05
+#define LED_CTRL_OFF_GRADUALLY 0x06
+
+/*LED glow speed code*/
+#define LED_SPEED_MAX 0x00
+#define LED_SPEED_HALF 0x50
+#define LED_SPEED_MIN 0xFF
+
+/*LED color code*/
+#define LED_COLOR_RED 0x01
+#define LED_COLOR_BLUE 0x02
+#define LED_COLOR_PURPLE 0x03
+
+struct r502a_led_params {
+	uint8_t ctrl_code;
+	uint8_t color_idx;
+	uint8_t speed; /* Speed 0x00-0xff */
+	uint8_t cycle; /* Number of cycles | 0-infinite, 1-255 */
+};
+
 enum sensor_channel_grow_r502a {
 	/** Fingerprint template count, ID number for enrolling and searching*/
 	SENSOR_CHAN_FINGERPRINT = SENSOR_CHAN_PRIV_START,
@@ -46,6 +71,8 @@ enum sensor_attribute_grow_r502a {
 	SENSOR_ATTR_R502A_CAPTURE,
 	/** To template data stored in sensor's RAM buffer*/
 	SENSOR_ATTR_R502A_COMPARE,
+	/** To control device LED */
+	SENSOR_ATTR_R502A_DEVICE_LED,
 };
 
 #ifdef __cplusplus

--- a/include/zephyr/drivers/sensor/grow_r502a.h
+++ b/include/zephyr/drivers/sensor/grow_r502a.h
@@ -38,6 +38,14 @@ enum sensor_attribute_grow_r502a {
 	SENSOR_ATTR_R502A_UPLOAD,
 	/** To download template data into the sensor */
 	SENSOR_ATTR_R502A_DOWNLOAD,
+	/** To load template from storage to RAM buffer of sensor*/
+	SENSOR_ATTR_R502A_RECORD_LOAD,
+	/** To store template to a record storage*/
+	SENSOR_ATTR_R502A_RECORD_STORE,
+	/** To capture finger data and put in sensor's RAM buffer */
+	SENSOR_ATTR_R502A_CAPTURE,
+	/** To template data stored in sensor's RAM buffer*/
+	SENSOR_ATTR_R502A_COMPARE,
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
Add the following functionality of the R502A fingerprint sensor device.

1. Add upload and download of fingerprint template data.
2. Add LED control for the R502A sensor's built-in LED.
3. Add Read and write system parameters of the R502A sensor.
4. Add precise matching of the given index with a provided finger.
5. Add capture, load, store, and compare templates of fingers with the R502A sensor.