### PR TITLE
Posix: ftruncate fix errno handling

### DIFF
--- a/doc/services/portability/posix/aep/index.rst
+++ b/doc/services/portability/posix/aep/index.rst
@@ -78,7 +78,7 @@ Realtime Controller System Profile (PSE52)
     POSIX_C_LANG_MATH, yes, :ref:`POSIX_C_LANG_MATH <posix_option_group_c_lang_math>`
     POSIX_C_LANG_SUPPORT, yes, :ref:`POSIX_C_LANG_SUPPORT <posix_option_group_c_lang_support>`
     POSIX_DEVICE_IO,, :ref:`†<posix_undefined_behaviour>`
-    POSIX_FD_MGMT,,
+    POSIX_FD_MGMT,, :ref:`POSIX_FD_MGMT <posix_option_group_fd_mgmt>`
     POSIX_FILE_LOCKING,,
     POSIX_FILE_SYSTEM,,
     POSIX_SIGNALS,, :ref:`†<posix_undefined_behaviour>`
@@ -135,7 +135,7 @@ Dedicated Realtime System Profile (PSE53)
     POSIX_C_LANG_MATH, yes, :ref:`POSIX_C_LANG_MATH <posix_option_group_c_lang_math>`
     POSIX_C_LANG_SUPPORT, yes, :ref:`POSIX_C_LANG_SUPPORT <posix_option_group_c_lang_support>`
     POSIX_DEVICE_IO,, :ref:`†<posix_undefined_behaviour>`
-    POSIX_FD_MGMT,,
+    POSIX_FD_MGMT,, :ref:`POSIX_FD_MGMT <posix_option_group_fd_mgmt>`
     POSIX_FILE_LOCKING,,
     POSIX_FILE_SYSTEM,,
     POSIX_MULTI_PROCESS,, :ref:`†<posix_undefined_behaviour>`

--- a/doc/services/portability/posix/conformance/index.rst
+++ b/doc/services/portability/posix/conformance/index.rst
@@ -80,7 +80,7 @@ POSIX System Interfaces
 
     _POSIX_ADVISORY_INFO, -1,
     _POSIX_CPUTIME, 200809L, :kconfig:option:`CONFIG_POSIX_CLOCK`
-    _POSIX_FSYNC, -1,
+    _POSIX_FSYNC, 200809L, :kconfig:option:`CONFIG_POSIX_FS`
     _POSIX_IPV6, 200809L, :kconfig:option:`CONFIG_NET_IPV6`
     _POSIX_MEMLOCK, -1,
     _POSIX_MEMLOCK_RANGE, -1,
@@ -92,7 +92,7 @@ POSIX System Interfaces
     _POSIX_SHARED_MEMORY_OBJECTS, -1,
     _POSIX_SPAWN, -1,
     _POSIX_SPORADIC_SERVER, -1,
-    _POSIX_SYNCHRONIZED_IO, -1,
+    _POSIX_SYNCHRONIZED_IO, -1, :kconfig:option:`CONFIG_POSIX_FS`
     :ref:`_POSIX_THREAD_ATTR_STACKADDR<posix_option_thread_attr_stackaddr>`, 200809L, :kconfig:option:`CONFIG_PTHREAD`
     _POSIX_THREAD_CPUTIME, -1,
     :ref:`_POSIX_THREAD_ATTR_STACKSIZE<posix_option_thread_attr_stacksize>`, 200809L, :kconfig:option:`CONFIG_PTHREAD`
@@ -146,7 +146,7 @@ XSI System Interfaces
    :header: Symbol, Support, Remarks
    :widths: 50, 10, 50
 
-    _POSIX_FSYNC, -1, :ref:`†<posix_undefined_behaviour>`
+    _POSIX_FSYNC, 200809L, :kconfig:option:`CONFIG_POSIX_FS`
     :ref:`_POSIX_THREAD_ATTR_STACKADDR<posix_option_thread_attr_stackaddr>`, 200809L, :kconfig:option:`CONFIG_PTHREAD`
     :ref:`_POSIX_THREAD_ATTR_STACKSIZE<posix_option_thread_attr_stacksize>`, 200809L, :kconfig:option:`CONFIG_PTHREAD`
     _POSIX_THREAD_PROCESS_SHARED, -1,

--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -406,11 +406,21 @@ POSIX_TIMERS
     timer_getoverrun(),yes
     timer_settime(),yes
 
-
 .. _posix_options:
 
 Additional POSIX Options
 ========================
+
+.. _posix_option_fsync:
+
+_POSIX_FSYNC
+++++++++++++
+
+.. csv-table:: _POSIX_FSYNC
+   :header: API, Supported
+   :widths: 50,10
+
+    fsync(),yes
 
 .. _posix_option_message_passing:
 
@@ -468,6 +478,19 @@ _POSIX_READER_WRITER_LOCKS
     pthread_rwlockattr_getpshared(),yes
     pthread_rwlockattr_init(),yes
     pthread_rwlockattr_setpshared(),yes
+
+.. _posix_option_synchronized_io:
+
+_POSIX_SYNCHRONIZED_IO
+++++++++++++++++++++++
+
+.. csv-table:: _POSIX_SYNCHRONIZED_IO
+   :header: API, Supported
+   :widths: 50,10
+
+    fdatasync(),
+    fsync(),yes
+    msync(),
 
 .. _posix_option_thread_attr_stackaddr:
 
@@ -575,7 +598,6 @@ _XOPEN_STREAMS
     isastream(),yes (will fail with ``ENOSYS``:ref:`†<posix_undefined_behaviour>`)
     putmsg(), yes (will fail with ``ENOSYS``:ref:`†<posix_undefined_behaviour>`)
     putpmsg(),
-
 
 .. _Subprofiling Considerations:
     https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_subprofiles.html

--- a/doc/services/portability/posix/option_groups/index.rst
+++ b/doc/services/portability/posix/option_groups/index.rst
@@ -406,6 +406,30 @@ POSIX_TIMERS
     timer_getoverrun(),yes
     timer_settime(),yes
 
+.. _posix_option_group_fd_mgmt:
+
+POSIX_FD_MGMT
+=============
+
+This table lists service support status in Zephyr for `POSIX_FD_MGMT`:
+
+.. csv-table:: POSIX_FD_MGMT
+   :header: API, Supported
+   :widths: 50,10
+
+    dup(),
+    dup2(),
+    fcntl(),
+    fgetpos(),
+    fseek(),
+    fseeko(),
+    fsetpos(),
+    ftell(),
+    ftello(),
+    ftruncate(),yes
+    lseek(),
+    rewind(),
+
 .. _posix_options:
 
 Additional POSIX Options

--- a/lib/posix/options/fs.c
+++ b/lib/posix/options/fs.c
@@ -423,11 +423,18 @@ int mkdir(const char *path, mode_t mode)
  */
 int ftruncate(int fd, off_t length)
 {
+	int rc;
 	struct posix_fs_desc *ptr = NULL;
 
 	ptr = z_get_fd_obj(fd, NULL, EBADF);
 	if (!ptr)
 		return -1;
 
-	return fs_truncate(&ptr->file, length);
+	rc = fs_truncate(&ptr->file, length);
+	if (rc < 0) {
+		errno = -rc;
+		return -1;
+	}
+
+	return 0;
 }


### PR DESCRIPTION
Fix errno handling for ftruncate and updated POISX doc for fsync and ftruncate