### PR TITLE
soc: mspm0g: override sys_arch_reboot() to trigger power-on reset

### DIFF
--- a/soc/ti/mspm0/mspm0g1x0x_g3x0x/soc.c
+++ b/soc/ti/mspm0/mspm0g1x0x_g3x0x/soc.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/init.h>
+#include <zephyr/sys/reboot.h>
 #include <ti/driverlib/m0p/dl_core.h>
 #include <soc.h>
 
@@ -17,6 +18,20 @@ static int ti_mspm0g_init(void)
 	DL_SYSCTL_setBORThreshold(DL_SYSCTL_BOR_THRESHOLD_LEVEL_0);
 
 	return 0;
+}
+
+/* Overrides the weak ARM implementation */
+void sys_arch_reboot(int type)
+{
+	switch (type)
+	{
+	case SYS_REBOOT_COLD:
+		DL_SYSCTL_resetDevice(DL_SYSCTL_RESET_POR);
+		break;
+	default:
+		NVIC_SystemReset();
+		break;
+	}
 }
 
 SYS_INIT(ti_mspm0g_init, PRE_KERNEL_1, 0);


### PR DESCRIPTION
The default implementation of sys_reboot(SYS_REBOOT_COLD) performs a CPU-only reset. 
This commit overrides the weak ARM implementation with a device-specific function for the MSPM0G series that triggers a power-on reset instead.
This ensures a more complete reset of the device when SYS_REBOOT_COLD is requested

