### PR TITLE
drivers: fuel_gauge: hy4245: Add some externed functionality and fix check sum issue.

### DIFF
--- a/drivers/fuel_gauge/hy4245/hy4245.c
+++ b/drivers/fuel_gauge/hy4245/hy4245.c
@@ -264,7 +264,7 @@ int hy4245_access_flash_data(const struct device *dev,
 			     bool is_read)
 {
 	int ret;
-	uint8_t cmd[] = { HY4245_EXTCMD_BLKDATA_CHECKSUM };
+	uint8_t cmd[2] = {HY4245_EXTCMD_BLKDATA_CHECKSUM};
 	const struct hy4245_config *cfg = dev->config;
 	struct hy4245_data *drvdata = dev->data;
 	uint8_t checksum = 0;

--- a/drivers/fuel_gauge/hy4245/hy4245.c
+++ b/drivers/fuel_gauge/hy4245/hy4245.c
@@ -315,6 +315,14 @@ int hy4245_access_flash_data(const struct device *dev,
 		if (ret < 0) {
 			goto err;
 		}
+		ret = hy4245_ctrl_status(dev, CTRL_STATUS_CSV);
+		if (ret < 0) {
+			goto err;
+		}
+
+		if ((ret & CTRL_STATUS_CSV) != CTRL_STATUS_CSV) {
+			goto err;
+		}
 	}
 	ret = i2c_write_read_dt(&cfg->i2c, cmd, 1, &resp, sizeof(resp));
 	if (ret < 0) {

--- a/drivers/fuel_gauge/hy4245/hy4245.c
+++ b/drivers/fuel_gauge/hy4245/hy4245.c
@@ -12,6 +12,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/logging/log.h>
 #include <string.h>
+#include <zephyr/drivers/fuel_gauge/hy4245.h>
 
 LOG_MODULE_REGISTER(HY4245);
 
@@ -34,6 +35,7 @@ LOG_MODULE_REGISTER(HY4245);
 #define HY4245_SUBCMD_CTRL_STATUS 	0x00
 #define HY4245_SUBCMD_CTRL_CHIPID	0x55
 #define HY4245_SUBCMD_CTRL_CALIB_MODE	0x40
+#define HY4245_SUBCMD_CTRL_RESET      0x41
 
 #define HY4245_EXTCMD_SUBCLASS		0x3E
 #define HY4245_EXTCMD_BLOCK		0x3F
@@ -322,6 +324,14 @@ int hy4245_access_flash_data(const struct device *dev,
 err:
 	k_mutex_unlock(&drvdata->mutex);
 	return ret;
+}
+
+int hy4245_reset(const struct device *dev)
+{
+	uint8_t cmd[3] = {HY4245_CMD_CTRL, HY4245_SUBCMD_CTRL_RESET};
+	const struct hy4245_config *cfg = dev->config;
+
+	return i2c_write_dt(&cfg->i2c, cmd, sizeof(cmd));
 }
 
 static int hy4245_get_prop(const struct device *dev, fuel_gauge_prop_t prop,

--- a/drivers/fuel_gauge/hy4245/hy4245.c
+++ b/drivers/fuel_gauge/hy4245/hy4245.c
@@ -315,6 +315,7 @@ int hy4245_access_flash_data(const struct device *dev,
 		if (ret < 0) {
 			goto err;
 		}
+
 		ret = hy4245_ctrl_status(dev, CTRL_STATUS_CSV);
 		if (ret < 0) {
 			goto err;

--- a/include/zephyr/drivers/fuel_gauge/hy4245.h
+++ b/include/zephyr/drivers/fuel_gauge/hy4245.h
@@ -11,19 +11,19 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_HY4245_H_
 #define ZEPHYR_INCLUDE_DRIVERS_HY4245_H_
 
-/**
- * @brief Charger Interface
- * @defgroup charger_interface Charger Interface
- * @ingroup io_interfaces
- * @{
- */
-
 #include <zephyr/device.h>
 #include <zephyr/drivers/fuel_gauge.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
+
+/**
+ * @brief Charger Interface
+ * @defgroup charger_interface Charger Interface
+ * @ingroup io_interfaces
+ * @{
+ */
 
 /**
  * @brief Set the HY4245 sensor into calibration mode.
@@ -81,6 +81,10 @@ int hy4245_access_flash_data(const struct device *dev, uint8_t subclass, uint8_t
  * failed.
  */
 int hy4245_reset(const struct device *dev);
+
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/drivers/fuel_gauge/hy4245.h
+++ b/include/zephyr/drivers/fuel_gauge/hy4245.h
@@ -1,0 +1,89 @@
+/*
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Charger APIs
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_HY4245_H_
+#define ZEPHYR_INCLUDE_DRIVERS_HY4245_H_
+
+/**
+ * @brief Charger Interface
+ * @defgroup charger_interface Charger Interface
+ * @ingroup io_interfaces
+ * @{
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/fuel_gauge.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * @brief Set the HY4245 sensor into calibration mode.
+ *
+ * This function puts the HY4245 sensor into calibration mode, allowing
+ * calibration data to be accessed and modified.
+ *
+ * @param dev Pointer to the device structure for the sensor.
+ *
+ * @return 0 if successful, error code otherwise.
+ */
+int hy4245_set_calibration_mode(const struct device *dev);
+
+/**
+ * @brief Enable flash access for the HY4245 sensor.
+ *
+ * This function enables access to the flash memory of the HY4245 sensor,
+ * which is required before performing any flash memory operations.
+ *
+ * @param dev Pointer to the device structure for the sensor.
+ *
+ * @return 0 if successful, error code otherwise.
+ */
+int hy4245_enable_flash_access(const struct device *dev);
+
+/**
+ * @brief Access flash data of the HY4245 sensor.
+ *
+ * This function allows reading from or writing to the flash memory of the
+ * HY4245 sensor. It is used to access calibration data or other parameters
+ * stored in the flash memory.
+ *
+ * @param dev Pointer to the device structure for the sensor.
+ * @param subclass Subclass of the data to access.
+ * @param block Block number within the subclass.
+ * @param data Buffer for the data to read or write.
+ * @param count Number of bytes to read or write.
+ * @param is_read Flag indicating whether to read (true) or write (false) data.
+ *
+ * @return 0 if successful, error code otherwise.
+ */
+int hy4245_access_flash_data(const struct device *dev, uint8_t subclass, uint8_t block,
+			     uint8_t *data, uint8_t count, bool is_read);
+
+/**
+ * @brief Resets the HY4245 device.
+ *
+ * This function performs a reset operation on the HY4245 device specified by the
+ * @a dev parameter. The reset process reinitializes the device to its default state,
+ * clearing any existing configurations or data. It is typically called when the device
+ * needs to be brought back to a known good state or when recovering from an error condition.
+ *
+ * @param dev Pointer to the device structure of the HY4245 device to be reset.
+ * @return int Returns 0 if the reset operation was successful, or a negative error code if it
+ * failed.
+ */
+int hy4245_reset(const struct device *dev);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_HY4245_H_ */


### PR DESCRIPTION
- Add the hy4245.h header file to implement the extended API functions.
- Move checksum calculation to the beginning for both read and write operations.
- Add checksum write functionality for flash write operations.
- Change fixed-size array to variable-length array for command buffer.
- Add CTRL_STATUS_CSV check before accessing flash data.
- Improve code readability by adding a newline after checking for errors.
- Move the Charger Interface documentation block to the top of the file
- Add missing closing brace for the documentation group
