### PR TITLE
drivers: sensor: bosch: Add bme688 compatiblity.

### DIFF
--- a/drivers/sensor/bosch/bme680/Kconfig
+++ b/drivers/sensor/bosch/bme680/Kconfig
@@ -2,7 +2,7 @@
 
 # Copyright (c) 2018 Bosch Sensortec GmbH
 # Copyright (c) 2022, Leonard Pollak
-#
+# Copyright (c) 2025, Linumiz GmbH
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig BME680
@@ -15,6 +15,16 @@ menuconfig BME680
 	  Enable driver for BME680 I2C- or SPI- based temperature, pressure, humidity and gas sensor.
 
 if BME680
+choice
+	prompt "BME680 mode selection"
+	default MODE_FORCED
+	help
+	  Select the required mode and parallel only support to bme688.
+config MODE_FORCED
+	bool "0x1"
+config MODE_PARALLEL
+	bool "0x2"
+endchoice
 
 choice
 	prompt "BME680 temperature oversampling"
@@ -115,4 +125,18 @@ config BME680_HEATR_DUR_ULP
 	bool "1943"
 endchoice
 
+config NB_CONV_VALUE
+	int "no of cycles"
+	default 0 if MODE_FORCED
+	default 1 if MODE_PARALLEL
+	range 0 9 if MODE_FORCED
+	range 1 10 if MODE_PARALLEL
+	help
+	  choose the no of cycles needed
+config CONV_TPHG_CYCLE
+	int "no of steps"
+	default 1
+	range 0 255
+	help 
+	  choose the no of steps
 endif # BME680


### PR DESCRIPTION
Add BME688 variant detection and gas resistance calculation. Implement parallel mode support for BME688 and add gas shared wait time calculation for parallel mode.