### PR TITLE
Dev/ifx/t2g evk

### DIFF
--- a/boards/infineon/kit_t2g_b_h_evk/kit_t2g_b_h_evk_common.dtsi
+++ b/boards/infineon/kit_t2g_b_h_evk/kit_t2g_b_h_evk_common.dtsi
@@ -157,64 +157,6 @@ i2c9: &scb9 {
     ifx,peri-div-inst = <1>;
 };
 
-&eth0_mac {
-	status = "okay";
-	pinctrl-0 = < &p26_2_eth_txd_0 &p26_3_eth_txd_1 &p26_4_eth_txd_2 &p26_5_eth_txd_3
-				&p26_0_eth_ref_clk &p26_1_eth_tx_en	&p26_6_eth_tx_clk
-				&p26_7_eth_rxd_0 &p27_0_eth_rxd_1 &p27_1_eth_rxd_2 &p27_2_eth_rxd_3
-				&p27_4_eth_rx_ctl &p27_3_eth_rx_clk  >;
-
-	pinctrl-names = "default";
-	phy-connection-type = "rgmii";
-
-	phy-handle = <&eth0_phy>;
-	clock-frequency = <125000000>;
-	local-mac-address = [b0 19 21 67 36 00];
-};
-
-&eth0_mdio {
-	status = "okay";
-	pinctrl-0 = <&p27_5_eth_mdc &p27_6_eth_mdio>;
-	pinctrl-names = "default";
-
-	eth0_phy: phy@1 {
-		compatible = "ti,dp83867";
-		reg = <0x1>;
-		status = "okay";
-		reset-gpios = <&gpio_prt27 7 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
-		ti,interface-type = "rgmii-id";
-		ti,rx-internal-delay = <8>;
-		ti,tx-internal-delay = <8>;
-	};
-};
-
-/* QSPI External NOR Flash */
-&smif0 {
-    status = "okay";
-    pinctrl-0 = <
-        &p6_3_smif0_clk &p6_5_smif0_sel0
-        &p7_1_smif0_data0 &p7_2_smif0_data1
-        &p7_3_smif0_data2 &p7_4_smif0_data3
-    >;
-    pinctrl-names = "default";
-
-    norflash0: s25hl512t@0 {
-		status ="okay";
-        compatible = "soc-nv-flash";
-        reg = <0x00000000 DT_SIZE_M(64)>;
-        write-block-size = <512>;
-        erase-block-size = <DT_SIZE_K(256)>;
-
-        partitions {
-            compatible = "fixed-partitions";
-            #address-cells = <1>;
-            #size-cells = <1>;
-        };
-
-    };
-};
-
-
 &can0 {
     status = "okay";
 };

--- a/dts/bindings/pwm/infineon,cat1-pwm.yaml
+++ b/dts/bindings/pwm/infineon,cat1-pwm.yaml
@@ -1,15 +1,13 @@
-# Copyright (c) 2024 Cypress Semiconductor Corporation (an Infineon company) or
-# an affiliate of Cypress Semiconductor Corporation
-#
-# SPDX-License-Identifier: Apache-2.0
-
-description: Infineon CAT1 PWM
-
-compatible: "infineon,cat1-pwm"
-
 include: [pwm-controller.yaml, pinctrl-device.yaml, "infineon,system-interrupts.yaml"]
 
+
 properties:
+  reg:
+    type: array
+    required: true
+    description: Register base address and size information
+
+
   pinctrl-0:
     description: |
       PORT pin configuration for the PWM signal.
@@ -18,12 +16,24 @@ properties:
       defines and have following
       format: p<port>_<pin>_<peripheral inst>_<signal>.
 
+
       Examples:
         pinctrl-0 = <&p1_1_pwm0_0>;
     required: true
 
+
   pinctrl-names:
     required: true
+
+
+  resolution:
+    type: int
+    required: true
+    description: Counter/timer resolution (16 or 32 bits)
+    enum:
+      - 16
+      - 32
+
 
   "#pwm-cells":
     const: 3
@@ -32,6 +42,7 @@ properties:
       - channel of the timer used for PWM (not used)
       - period to set in ns
       - flags: standard flags like PWM_POLARITY_NORMAL
+
 
 pwm-cells:
   - channel

--- a/samples/subsys/ipc/openamp/boards/kit_t2g_b_h_evk_cyt4bfbche_m0p.conf
+++ b/samples/subsys/ipc/openamp/boards/kit_t2g_b_h_evk_cyt4bfbche_m0p.conf
@@ -1,0 +1,2 @@
+# OpenAMP Host configuration for kit_t2g_b_h_evk (CM0P)
+CONFIG_MBOX=y

--- a/samples/subsys/ipc/openamp/boards/kit_t2g_b_h_evk_cyt4bfbche_m0p.overlay
+++ b/samples/subsys/ipc/openamp/boards/kit_t2g_b_h_evk_cyt4bfbche_m0p.overlay
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2026 Infineon Technologies AG
  * SPDX-License-Identifier: Apache-2.0
+ *
  */
 
 / {
@@ -11,7 +12,7 @@
 
 	ipm0: ipm@0 {
 		compatible = "zephyr,mbox-ipm";
-		mboxes = <&mbox 1>, <&mbox 0>;
+		mboxes = <&mbox 0>, <&mbox 1>;
 		mbox-names = "tx", "rx";
 		status = "okay";
 	};
@@ -21,12 +22,14 @@
 		#size-cells = <1>;
 
 		/*
-		 * Address: 0x2807C000
+		 * Shared memory region for IPC between CM0P and CM7_1
+		 * Located at the end of sram_m7_0 region
+		 * Address: 0x2803C000 (M7_0 end - 16KB)
 		 * Size: 16KB (0x4000)
 		 */
 		ipc_shm0: memory@2807c000 {
-			compatible = "mmio-sram";
-			reg = <0x2807c000 0x4000>;
+    		compatible = "mmio-sram";
+   			reg = <0x2807c000 0x4000>;
 		};
 	};
 };

--- a/samples/subsys/ipc/openamp/boards/kit_t2g_b_h_evk_cyt4bfbche_m7_0.overlay
+++ b/samples/subsys/ipc/openamp/boards/kit_t2g_b_h_evk_cyt4bfbche_m7_0.overlay
@@ -23,14 +23,14 @@
 		#size-cells = <1>;
 
 		/*
-		 * Shared memory region for IPC between CM7_0 and M0+/M7_1
-		 * Located in sram2 to avoid conflicts
-		 * Address: 0x28080000 (start of sram2)
+		 * Shared memory region for IPC between CM7_0 and CM7_1
+		 * Located at the end of sram_m7_1 region to avoid overlap
+		 * Address: 0x2807C000 (M7_1 end - 16KB)
 		 * Size: 16KB (0x4000)
 		 */
-		ipc_shm0: memory@28080000 {
+		ipc_shm0: memory@2807c000 {
 			compatible = "mmio-sram";
-			reg = <0x28080000 0x4000>;
+			reg = <0x2807c000 0x4000>;
 		};
 	};
 };


### PR DESCRIPTION
1. Added overlay files for validating IPC.
2. Modified dts: bindings: pwm: infineon,cat1 for compilation fix.
3. Removed the nodes for not tested IP.