### PR TITLE
boards: infineon: kit_t2g_b_h_evk: Remove ethernet, smif node and add openAMP overlay files for ipc testing

### DIFF
--- a/boards/infineon/kit_t2g_b_h_evk/kit_t2g_b_h_evk_common.dtsi
+++ b/boards/infineon/kit_t2g_b_h_evk/kit_t2g_b_h_evk_common.dtsi
@@ -157,64 +157,6 @@ i2c9: &scb9 {
     ifx,peri-div-inst = <1>;
 };
 
-&eth0_mac {
-	status = "okay";
-	pinctrl-0 = < &p26_2_eth_txd_0 &p26_3_eth_txd_1 &p26_4_eth_txd_2 &p26_5_eth_txd_3
-				&p26_0_eth_ref_clk &p26_1_eth_tx_en	&p26_6_eth_tx_clk
-				&p26_7_eth_rxd_0 &p27_0_eth_rxd_1 &p27_1_eth_rxd_2 &p27_2_eth_rxd_3
-				&p27_4_eth_rx_ctl &p27_3_eth_rx_clk  >;
-
-	pinctrl-names = "default";
-	phy-connection-type = "rgmii";
-
-	phy-handle = <&eth0_phy>;
-	clock-frequency = <125000000>;
-	local-mac-address = [b0 19 21 67 36 00];
-};
-
-&eth0_mdio {
-	status = "okay";
-	pinctrl-0 = <&p27_5_eth_mdc &p27_6_eth_mdio>;
-	pinctrl-names = "default";
-
-	eth0_phy: phy@1 {
-		compatible = "ti,dp83867";
-		reg = <0x1>;
-		status = "okay";
-		reset-gpios = <&gpio_prt27 7 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
-		ti,interface-type = "rgmii-id";
-		ti,rx-internal-delay = <8>;
-		ti,tx-internal-delay = <8>;
-	};
-};
-
-/* QSPI External NOR Flash */
-&smif0 {
-    status = "okay";
-    pinctrl-0 = <
-        &p6_3_smif0_clk &p6_5_smif0_sel0
-        &p7_1_smif0_data0 &p7_2_smif0_data1
-        &p7_3_smif0_data2 &p7_4_smif0_data3
-    >;
-    pinctrl-names = "default";
-
-    norflash0: s25hl512t@0 {
-		status ="okay";
-        compatible = "soc-nv-flash";
-        reg = <0x00000000 DT_SIZE_M(64)>;
-        write-block-size = <512>;
-        erase-block-size = <DT_SIZE_K(256)>;
-
-        partitions {
-            compatible = "fixed-partitions";
-            #address-cells = <1>;
-            #size-cells = <1>;
-        };
-
-    };
-};
-
-
 &can0 {
     status = "okay";
 };

--- a/dts/arm/infineon/cat1c/traveo2-8m/cyt4bfb-pinctrl.dtsi
+++ b/dts/arm/infineon/cat1c/traveo2-8m/cyt4bfb-pinctrl.dtsi
@@ -1,0 +1,1494 @@
+/*
+ * Copyright (c) 2023 Cypress Semiconductor Corporation (an Infineon company) or
+ * an affiliate of Cypress Semiconductor Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/pinctrl/ifx_cat1-pinctrl.h>
+#include "cyt4bf.dtsi"
+
+/ {
+	soc {
+		/delete-node/ gpio@40311080; // gpio_prt33
+		/delete-node/ gpio@40311100; // gpio_prt34
+
+		pinctrl: pinctrl@40300000 {
+			/* scb_i2c_scl */
+			/omit-if-no-ref/ p0_1_scb7_i2c_scl: p0_1_scb7_i2c_scl {
+				pinmux = <DT_CAT1_PINMUX(0, 1, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p0_2_scb0_i2c_scl: p0_2_scb0_i2c_scl {
+				pinmux = <DT_CAT1_PINMUX(0, 2, HSIOM_SEL_DS_2)>;
+			};
+			/omit-if-no-ref/ p1_0_scb0_i2c_scl: p1_0_scb0_i2c_scl {
+				pinmux = <DT_CAT1_PINMUX(1, 0, HSIOM_SEL_DS_2)>;
+			};
+			/omit-if-no-ref/ p2_2_scb7_i2c_scl: p2_2_scb7_i2c_scl {
+				pinmux = <DT_CAT1_PINMUX(2, 2, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p3_2_scb6_i2c_scl: p3_2_scb6_i2c_scl {
+				pinmux = <DT_CAT1_PINMUX(3, 2, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p4_2_scb5_i2c_scl: p4_2_scb5_i2c_scl {
+				pinmux = <DT_CAT1_PINMUX(4, 2, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p6_2_scb4_i2c_scl: p6_2_scb4_i2c_scl {
+				pinmux = <DT_CAT1_PINMUX(6, 2, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p7_2_scb5_i2c_scl: p7_2_scb5_i2c_scl {
+				pinmux = <DT_CAT1_PINMUX(7, 2, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p10_2_scb4_i2c_scl: p10_2_scb4_i2c_scl {
+				pinmux = <DT_CAT1_PINMUX(10, 2, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p12_2_scb8_i2c_scl: p12_2_scb8_i2c_scl {
+				pinmux = <DT_CAT1_PINMUX(12, 2, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p13_2_scb3_i2c_scl: p13_2_scb3_i2c_scl {
+				pinmux = <DT_CAT1_PINMUX(13, 2, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p14_2_scb2_i2c_scl: p14_2_scb2_i2c_scl {
+				pinmux = <DT_CAT1_PINMUX(14, 2, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p15_2_scb9_i2c_scl: p15_2_scb9_i2c_scl {
+				pinmux = <DT_CAT1_PINMUX(15, 2, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p17_3_scb3_i2c_scl: p17_3_scb3_i2c_scl {
+				pinmux = <DT_CAT1_PINMUX(17, 3, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p18_2_scb1_i2c_scl: p18_2_scb1_i2c_scl {
+				pinmux = <DT_CAT1_PINMUX(18, 2, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p19_2_scb2_i2c_scl: p19_2_scb2_i2c_scl {
+				pinmux = <DT_CAT1_PINMUX(19, 2, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p20_5_scb1_i2c_scl: p20_5_scb1_i2c_scl {
+				pinmux = <DT_CAT1_PINMUX(20, 5, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p22_2_scb6_i2c_scl: p22_2_scb6_i2c_scl {
+				pinmux = <DT_CAT1_PINMUX(22, 2, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p23_2_scb7_i2c_scl: p23_2_scb7_i2c_scl {
+				pinmux = <DT_CAT1_PINMUX(23, 2, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p28_2_scb10_i2c_scl: p28_2_scb10_i2c_scl {
+				pinmux = <DT_CAT1_PINMUX(28, 2, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p30_0_scb9_i2c_scl: p30_0_scb9_i2c_scl {
+				pinmux = <DT_CAT1_PINMUX(30, 0, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p32_2_scb10_i2c_scl: p32_2_scb10_i2c_scl {
+				pinmux = <DT_CAT1_PINMUX(32, 2, HSIOM_SEL_ACT_6)>;
+			};
+
+			/* scb_i2c_sda */
+			/omit-if-no-ref/ p0_0_scb7_i2c_sda: p0_0_scb7_i2c_sda {
+				pinmux = <DT_CAT1_PINMUX(0, 0, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p0_3_scb0_i2c_sda: p0_3_scb0_i2c_sda {
+				pinmux = <DT_CAT1_PINMUX(0, 3, HSIOM_SEL_DS_2)>;
+			};
+			/omit-if-no-ref/ p1_1_scb0_i2c_sda: p1_1_scb0_i2c_sda {
+				pinmux = <DT_CAT1_PINMUX(1, 1, HSIOM_SEL_DS_2)>;
+			};
+			/omit-if-no-ref/ p2_1_scb7_i2c_sda: p2_1_scb7_i2c_sda {
+				pinmux = <DT_CAT1_PINMUX(2, 1, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p3_1_scb6_i2c_sda: p3_1_scb6_i2c_sda {
+				pinmux = <DT_CAT1_PINMUX(3, 1, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p4_1_scb5_i2c_sda: p4_1_scb5_i2c_sda {
+				pinmux = <DT_CAT1_PINMUX(4, 1, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p6_1_scb4_i2c_sda: p6_1_scb4_i2c_sda {
+				pinmux = <DT_CAT1_PINMUX(6, 1, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p7_1_scb5_i2c_sda: p7_1_scb5_i2c_sda {
+				pinmux = <DT_CAT1_PINMUX(7, 1, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p10_1_scb4_i2c_sda: p10_1_scb4_i2c_sda {
+				pinmux = <DT_CAT1_PINMUX(10, 1, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p12_1_scb8_i2c_sda: p12_1_scb8_i2c_sda {
+				pinmux = <DT_CAT1_PINMUX(12, 1, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p13_1_scb3_i2c_sda: p13_1_scb3_i2c_sda {
+				pinmux = <DT_CAT1_PINMUX(13, 1, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p14_1_scb2_i2c_sda: p14_1_scb2_i2c_sda {
+				pinmux = <DT_CAT1_PINMUX(14, 1, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p15_1_scb9_i2c_sda: p15_1_scb9_i2c_sda {
+				pinmux = <DT_CAT1_PINMUX(15, 1, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p17_2_scb3_i2c_sda: p17_2_scb3_i2c_sda {
+				pinmux = <DT_CAT1_PINMUX(17, 2, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p18_1_scb1_i2c_sda: p18_1_scb1_i2c_sda {
+				pinmux = <DT_CAT1_PINMUX(18, 1, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p19_1_scb2_i2c_sda: p19_1_scb2_i2c_sda {
+				pinmux = <DT_CAT1_PINMUX(19, 1, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p20_4_scb1_i2c_sda: p20_4_scb1_i2c_sda {
+				pinmux = <DT_CAT1_PINMUX(20, 4, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p22_1_scb6_i2c_sda: p22_1_scb6_i2c_sda {
+				pinmux = <DT_CAT1_PINMUX(22, 1, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p23_1_scb7_i2c_sda: p23_1_scb7_i2c_sda {
+				pinmux = <DT_CAT1_PINMUX(23, 1, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p28_1_scb10_i2c_sda: p28_1_scb10_i2c_sda {
+				pinmux = <DT_CAT1_PINMUX(28, 1, HSIOM_SEL_ACT_6)>;
+			};
+			/omit-if-no-ref/ p32_1_scb10_i2c_sda: p32_1_scb10_i2c_sda {
+				pinmux = <DT_CAT1_PINMUX(32, 1, HSIOM_SEL_ACT_6)>;
+			};
+
+			/* scb_spi_m_clk */
+			/omit-if-no-ref/ p0_2_scb0_spi_m_clk: p0_2_scb0_spi_m_clk {
+				pinmux = <DT_CAT1_PINMUX(0, 2, HSIOM_SEL_DS_6)>;
+			};
+			/omit-if-no-ref/ p1_0_scb4_spi_m_clk: p1_0_scb4_spi_m_clk {
+				pinmux = <DT_CAT1_PINMUX(1, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p1_2_scb0_spi_m_clk: p1_2_scb0_spi_m_clk {
+				pinmux = <DT_CAT1_PINMUX(1, 2, HSIOM_SEL_DS_6)>;
+			};
+			/omit-if-no-ref/ p2_2_scb7_spi_m_clk: p2_2_scb7_spi_m_clk {
+				pinmux = <DT_CAT1_PINMUX(2, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p3_2_scb6_spi_m_clk: p3_2_scb6_spi_m_clk {
+				pinmux = <DT_CAT1_PINMUX(3, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p4_2_scb5_spi_m_clk: p4_2_scb5_spi_m_clk {
+				pinmux = <DT_CAT1_PINMUX(4, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p6_2_scb4_spi_m_clk: p6_2_scb4_spi_m_clk {
+				pinmux = <DT_CAT1_PINMUX(6, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p7_2_scb5_spi_m_clk: p7_2_scb5_spi_m_clk {
+				pinmux = <DT_CAT1_PINMUX(7, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p10_2_scb4_spi_m_clk: p10_2_scb4_spi_m_clk {
+				pinmux = <DT_CAT1_PINMUX(10, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p12_2_scb8_spi_m_clk: p12_2_scb8_spi_m_clk {
+				pinmux = <DT_CAT1_PINMUX(12, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p13_2_scb3_spi_m_clk: p13_2_scb3_spi_m_clk {
+				pinmux = <DT_CAT1_PINMUX(13, 2, HSIOM_SEL_ACT_9)>;
+			};
+			/omit-if-no-ref/ p14_2_scb2_spi_m_clk: p14_2_scb2_spi_m_clk {
+				pinmux = <DT_CAT1_PINMUX(14, 2, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p15_2_scb9_spi_m_clk: p15_2_scb9_spi_m_clk {
+				pinmux = <DT_CAT1_PINMUX(15, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p17_3_scb3_spi_m_clk: p17_3_scb3_spi_m_clk {
+				pinmux = <DT_CAT1_PINMUX(17, 3, HSIOM_SEL_ACT_9)>;
+			};
+			/omit-if-no-ref/ p18_2_scb1_spi_m_clk: p18_2_scb1_spi_m_clk {
+				pinmux = <DT_CAT1_PINMUX(18, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p18_3_scb3_spi_m_clk: p18_3_scb3_spi_m_clk {
+				pinmux = <DT_CAT1_PINMUX(18, 3, HSIOM_SEL_ACT_9)>;
+			};
+			/omit-if-no-ref/ p19_2_scb2_spi_m_clk: p19_2_scb2_spi_m_clk {
+				pinmux = <DT_CAT1_PINMUX(19, 2, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p20_5_scb1_spi_m_clk: p20_5_scb1_spi_m_clk {
+				pinmux = <DT_CAT1_PINMUX(20, 5, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p22_2_scb6_spi_m_clk: p22_2_scb6_spi_m_clk {
+				pinmux = <DT_CAT1_PINMUX(22, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p23_2_scb7_spi_m_clk: p23_2_scb7_spi_m_clk {
+				pinmux = <DT_CAT1_PINMUX(23, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p23_6_scb2_spi_m_clk: p23_6_scb2_spi_m_clk {
+				pinmux = <DT_CAT1_PINMUX(23, 6, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p28_2_scb10_spi_m_clk: p28_2_scb10_spi_m_clk {
+				pinmux = <DT_CAT1_PINMUX(28, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p30_0_scb9_spi_m_clk: p30_0_scb9_spi_m_clk {
+				pinmux = <DT_CAT1_PINMUX(30, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p32_2_scb10_spi_m_clk: p32_2_scb10_spi_m_clk {
+				pinmux = <DT_CAT1_PINMUX(32, 2, HSIOM_SEL_ACT_7)>;
+			};
+
+			/* scb_spi_m_miso */
+			/omit-if-no-ref/ p0_0_scb0_spi_m_miso: p0_0_scb0_spi_m_miso {
+				pinmux = <DT_CAT1_PINMUX(0, 0, HSIOM_SEL_DS_6)>;
+			};
+			/omit-if-no-ref/ p0_2_scb4_spi_m_miso: p0_2_scb4_spi_m_miso {
+				pinmux = <DT_CAT1_PINMUX(0, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p1_0_scb0_spi_m_miso: p1_0_scb0_spi_m_miso {
+				pinmux = <DT_CAT1_PINMUX(1, 0, HSIOM_SEL_DS_6)>;
+			};
+			/omit-if-no-ref/ p1_4_scb8_spi_m_miso: p1_4_scb8_spi_m_miso {
+				pinmux = <DT_CAT1_PINMUX(1, 4, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p2_0_scb7_spi_m_miso: p2_0_scb7_spi_m_miso {
+				pinmux = <DT_CAT1_PINMUX(2, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p3_0_scb6_spi_m_miso: p3_0_scb6_spi_m_miso {
+				pinmux = <DT_CAT1_PINMUX(3, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p4_0_scb5_spi_m_miso: p4_0_scb5_spi_m_miso {
+				pinmux = <DT_CAT1_PINMUX(4, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p6_0_scb4_spi_m_miso: p6_0_scb4_spi_m_miso {
+				pinmux = <DT_CAT1_PINMUX(6, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p7_0_scb5_spi_m_miso: p7_0_scb5_spi_m_miso {
+				pinmux = <DT_CAT1_PINMUX(7, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p10_0_scb4_spi_m_miso: p10_0_scb4_spi_m_miso {
+				pinmux = <DT_CAT1_PINMUX(10, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p12_0_scb8_spi_m_miso: p12_0_scb8_spi_m_miso {
+				pinmux = <DT_CAT1_PINMUX(12, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p13_0_scb3_spi_m_miso: p13_0_scb3_spi_m_miso {
+				pinmux = <DT_CAT1_PINMUX(13, 0, HSIOM_SEL_ACT_9)>;
+			};
+			/omit-if-no-ref/ p14_0_scb2_spi_m_miso: p14_0_scb2_spi_m_miso {
+				pinmux = <DT_CAT1_PINMUX(14, 0, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p15_0_scb9_spi_m_miso: p15_0_scb9_spi_m_miso {
+				pinmux = <DT_CAT1_PINMUX(15, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p18_0_scb1_spi_m_miso: p18_0_scb1_spi_m_miso {
+				pinmux = <DT_CAT1_PINMUX(18, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p18_1_scb3_spi_m_miso: p18_1_scb3_spi_m_miso {
+				pinmux = <DT_CAT1_PINMUX(18, 1, HSIOM_SEL_ACT_9)>;
+			};
+			/omit-if-no-ref/ p19_0_scb2_spi_m_miso: p19_0_scb2_spi_m_miso {
+				pinmux = <DT_CAT1_PINMUX(19, 0, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p20_3_scb1_spi_m_miso: p20_3_scb1_spi_m_miso {
+				pinmux = <DT_CAT1_PINMUX(20, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p21_7_scb6_spi_m_miso: p21_7_scb6_spi_m_miso {
+				pinmux = <DT_CAT1_PINMUX(21, 7, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p23_0_scb7_spi_m_miso: p23_0_scb7_spi_m_miso {
+				pinmux = <DT_CAT1_PINMUX(23, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p23_4_scb2_spi_m_miso: p23_4_scb2_spi_m_miso {
+				pinmux = <DT_CAT1_PINMUX(23, 4, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p28_0_scb10_spi_m_miso: p28_0_scb10_spi_m_miso {
+				pinmux = <DT_CAT1_PINMUX(28, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p32_0_scb10_spi_m_miso: p32_0_scb10_spi_m_miso {
+				pinmux = <DT_CAT1_PINMUX(32, 0, HSIOM_SEL_ACT_7)>;
+			};
+
+			/* scb_spi_m_mosi */
+			/omit-if-no-ref/ p0_1_scb0_spi_m_mosi: p0_1_scb0_spi_m_mosi {
+				pinmux = <DT_CAT1_PINMUX(0, 1, HSIOM_SEL_DS_6)>;
+			};
+			/omit-if-no-ref/ p0_3_scb4_spi_m_mosi: p0_3_scb4_spi_m_mosi {
+				pinmux = <DT_CAT1_PINMUX(0, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p1_1_scb0_spi_m_mosi: p1_1_scb0_spi_m_mosi {
+				pinmux = <DT_CAT1_PINMUX(1, 1, HSIOM_SEL_DS_6)>;
+			};
+			/omit-if-no-ref/ p2_1_scb7_spi_m_mosi: p2_1_scb7_spi_m_mosi {
+				pinmux = <DT_CAT1_PINMUX(2, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p3_1_scb6_spi_m_mosi: p3_1_scb6_spi_m_mosi {
+				pinmux = <DT_CAT1_PINMUX(3, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p4_1_scb5_spi_m_mosi: p4_1_scb5_spi_m_mosi {
+				pinmux = <DT_CAT1_PINMUX(4, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p6_1_scb4_spi_m_mosi: p6_1_scb4_spi_m_mosi {
+				pinmux = <DT_CAT1_PINMUX(6, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p7_1_scb5_spi_m_mosi: p7_1_scb5_spi_m_mosi {
+				pinmux = <DT_CAT1_PINMUX(7, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p10_1_scb4_spi_m_mosi: p10_1_scb4_spi_m_mosi {
+				pinmux = <DT_CAT1_PINMUX(10, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p12_1_scb8_spi_m_mosi: p12_1_scb8_spi_m_mosi {
+				pinmux = <DT_CAT1_PINMUX(12, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p13_1_scb3_spi_m_mosi: p13_1_scb3_spi_m_mosi {
+				pinmux = <DT_CAT1_PINMUX(13, 1, HSIOM_SEL_ACT_9)>;
+			};
+			/omit-if-no-ref/ p14_1_scb2_spi_m_mosi: p14_1_scb2_spi_m_mosi {
+				pinmux = <DT_CAT1_PINMUX(14, 1, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p15_1_scb9_spi_m_mosi: p15_1_scb9_spi_m_mosi {
+				pinmux = <DT_CAT1_PINMUX(15, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p18_1_scb1_spi_m_mosi: p18_1_scb1_spi_m_mosi {
+				pinmux = <DT_CAT1_PINMUX(18, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p18_2_scb3_spi_m_mosi: p18_2_scb3_spi_m_mosi {
+				pinmux = <DT_CAT1_PINMUX(18, 2, HSIOM_SEL_ACT_9)>;
+			};
+			/omit-if-no-ref/ p19_1_scb2_spi_m_mosi: p19_1_scb2_spi_m_mosi {
+				pinmux = <DT_CAT1_PINMUX(19, 1, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p20_4_scb1_spi_m_mosi: p20_4_scb1_spi_m_mosi {
+				pinmux = <DT_CAT1_PINMUX(20, 4, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p22_1_scb6_spi_m_mosi: p22_1_scb6_spi_m_mosi {
+				pinmux = <DT_CAT1_PINMUX(22, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p23_1_scb7_spi_m_mosi: p23_1_scb7_spi_m_mosi {
+				pinmux = <DT_CAT1_PINMUX(23, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p23_5_scb2_spi_m_mosi: p23_5_scb2_spi_m_mosi {
+				pinmux = <DT_CAT1_PINMUX(23, 5, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p28_1_scb10_spi_m_mosi: p28_1_scb10_spi_m_mosi {
+				pinmux = <DT_CAT1_PINMUX(28, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p32_1_scb10_spi_m_mosi: p32_1_scb10_spi_m_mosi {
+				pinmux = <DT_CAT1_PINMUX(32, 1, HSIOM_SEL_ACT_7)>;
+			};
+
+			/* scb_spi_m_select0 */
+			/omit-if-no-ref/ p0_3_scb0_spi_m_select0: p0_3_scb0_spi_m_select0 {
+				pinmux = <DT_CAT1_PINMUX(0, 3, HSIOM_SEL_DS_6)>;
+			};
+			/omit-if-no-ref/ p1_1_scb4_spi_m_select0: p1_1_scb4_spi_m_select0 {
+				pinmux = <DT_CAT1_PINMUX(1, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p1_3_scb0_spi_m_select0: p1_3_scb0_spi_m_select0 {
+				pinmux = <DT_CAT1_PINMUX(1, 3, HSIOM_SEL_DS_6)>;
+			};
+			/omit-if-no-ref/ p2_3_scb7_spi_m_select0: p2_3_scb7_spi_m_select0 {
+				pinmux = <DT_CAT1_PINMUX(2, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p2_6_scb8_spi_m_select0: p2_6_scb8_spi_m_select0 {
+				pinmux = <DT_CAT1_PINMUX(2, 6, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p3_3_scb6_spi_m_select0: p3_3_scb6_spi_m_select0 {
+				pinmux = <DT_CAT1_PINMUX(3, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p4_3_scb5_spi_m_select0: p4_3_scb5_spi_m_select0 {
+				pinmux = <DT_CAT1_PINMUX(4, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p6_3_scb4_spi_m_select0: p6_3_scb4_spi_m_select0 {
+				pinmux = <DT_CAT1_PINMUX(6, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p7_3_scb5_spi_m_select0: p7_3_scb5_spi_m_select0 {
+				pinmux = <DT_CAT1_PINMUX(7, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p10_3_scb4_spi_m_select0: p10_3_scb4_spi_m_select0 {
+				pinmux = <DT_CAT1_PINMUX(10, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p12_3_scb8_spi_m_select0: p12_3_scb8_spi_m_select0 {
+				pinmux = <DT_CAT1_PINMUX(12, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p13_3_scb3_spi_m_select0: p13_3_scb3_spi_m_select0 {
+				pinmux = <DT_CAT1_PINMUX(13, 3, HSIOM_SEL_ACT_9)>;
+			};
+			/omit-if-no-ref/ p14_3_scb2_spi_m_select0: p14_3_scb2_spi_m_select0 {
+				pinmux = <DT_CAT1_PINMUX(14, 3, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p15_3_scb9_spi_m_select0: p15_3_scb9_spi_m_select0 {
+				pinmux = <DT_CAT1_PINMUX(15, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p17_4_scb3_spi_m_select0: p17_4_scb3_spi_m_select0 {
+				pinmux = <DT_CAT1_PINMUX(17, 4, HSIOM_SEL_ACT_9)>;
+			};
+			/omit-if-no-ref/ p18_3_scb1_spi_m_select0: p18_3_scb1_spi_m_select0 {
+				pinmux = <DT_CAT1_PINMUX(18, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p18_4_scb3_spi_m_select0: p18_4_scb3_spi_m_select0 {
+				pinmux = <DT_CAT1_PINMUX(18, 4, HSIOM_SEL_ACT_9)>;
+			};
+			/omit-if-no-ref/ p19_3_scb2_spi_m_select0: p19_3_scb2_spi_m_select0 {
+				pinmux = <DT_CAT1_PINMUX(19, 3, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p20_6_scb1_spi_m_select0: p20_6_scb1_spi_m_select0 {
+				pinmux = <DT_CAT1_PINMUX(20, 6, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p22_3_scb6_spi_m_select0: p22_3_scb6_spi_m_select0 {
+				pinmux = <DT_CAT1_PINMUX(22, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p23_3_scb7_spi_m_select0: p23_3_scb7_spi_m_select0 {
+				pinmux = <DT_CAT1_PINMUX(23, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p23_7_scb2_spi_m_select0: p23_7_scb2_spi_m_select0 {
+				pinmux = <DT_CAT1_PINMUX(23, 7, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p28_3_scb10_spi_m_select0: p28_3_scb10_spi_m_select0 {
+				pinmux = <DT_CAT1_PINMUX(28, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p30_1_scb9_spi_m_select0: p30_1_scb9_spi_m_select0 {
+				pinmux = <DT_CAT1_PINMUX(30, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p32_3_scb10_spi_m_select0: p32_3_scb10_spi_m_select0 {
+				pinmux = <DT_CAT1_PINMUX(32, 3, HSIOM_SEL_ACT_7)>;
+			};
+
+			/* scb_spi_m_select1 */
+			/omit-if-no-ref/ p2_0_scb0_spi_m_select1: p2_0_scb0_spi_m_select1 {
+				pinmux = <DT_CAT1_PINMUX(2, 0, HSIOM_SEL_DS_6)>;
+			};
+			/omit-if-no-ref/ p2_4_scb7_spi_m_select1: p2_4_scb7_spi_m_select1 {
+				pinmux = <DT_CAT1_PINMUX(2, 4, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p2_7_scb8_spi_m_select1: p2_7_scb8_spi_m_select1 {
+				pinmux = <DT_CAT1_PINMUX(2, 7, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p3_4_scb6_spi_m_select1: p3_4_scb6_spi_m_select1 {
+				pinmux = <DT_CAT1_PINMUX(3, 4, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p4_4_scb5_spi_m_select1: p4_4_scb5_spi_m_select1 {
+				pinmux = <DT_CAT1_PINMUX(4, 4, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p6_4_scb4_spi_m_select1: p6_4_scb4_spi_m_select1 {
+				pinmux = <DT_CAT1_PINMUX(6, 4, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p7_4_scb5_spi_m_select1: p7_4_scb5_spi_m_select1 {
+				pinmux = <DT_CAT1_PINMUX(7, 4, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p10_4_scb4_spi_m_select1: p10_4_scb4_spi_m_select1 {
+				pinmux = <DT_CAT1_PINMUX(10, 4, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p12_4_scb8_spi_m_select1: p12_4_scb8_spi_m_select1 {
+				pinmux = <DT_CAT1_PINMUX(12, 4, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p13_4_scb3_spi_m_select1: p13_4_scb3_spi_m_select1 {
+				pinmux = <DT_CAT1_PINMUX(13, 4, HSIOM_SEL_ACT_9)>;
+			};
+			/omit-if-no-ref/ p14_4_scb2_spi_m_select1: p14_4_scb2_spi_m_select1 {
+				pinmux = <DT_CAT1_PINMUX(14, 4, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p16_0_scb9_spi_m_select1: p16_0_scb9_spi_m_select1 {
+				pinmux = <DT_CAT1_PINMUX(16, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p17_5_scb3_spi_m_select1: p17_5_scb3_spi_m_select1 {
+				pinmux = <DT_CAT1_PINMUX(17, 5, HSIOM_SEL_ACT_9)>;
+			};
+			/omit-if-no-ref/ p18_4_scb1_spi_m_select1: p18_4_scb1_spi_m_select1 {
+				pinmux = <DT_CAT1_PINMUX(18, 4, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p19_4_scb2_spi_m_select1: p19_4_scb2_spi_m_select1 {
+				pinmux = <DT_CAT1_PINMUX(19, 4, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p20_7_scb1_spi_m_select1: p20_7_scb1_spi_m_select1 {
+				pinmux = <DT_CAT1_PINMUX(20, 7, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p22_4_scb6_spi_m_select1: p22_4_scb6_spi_m_select1 {
+				pinmux = <DT_CAT1_PINMUX(22, 4, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p23_4_scb7_spi_m_select1: p23_4_scb7_spi_m_select1 {
+				pinmux = <DT_CAT1_PINMUX(23, 4, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p28_4_scb10_spi_m_select1: p28_4_scb10_spi_m_select1 {
+				pinmux = <DT_CAT1_PINMUX(28, 4, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p30_2_scb9_spi_m_select1: p30_2_scb9_spi_m_select1 {
+				pinmux = <DT_CAT1_PINMUX(30, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p32_4_scb10_spi_m_select1: p32_4_scb10_spi_m_select1 {
+				pinmux = <DT_CAT1_PINMUX(32, 4, HSIOM_SEL_ACT_7)>;
+			};
+
+			/* scb_spi_m_select2 */
+			/omit-if-no-ref/ p2_1_scb0_spi_m_select2: p2_1_scb0_spi_m_select2 {
+				pinmux = <DT_CAT1_PINMUX(2, 1, HSIOM_SEL_DS_6)>;
+			};
+			/omit-if-no-ref/ p2_5_scb7_spi_m_select2: p2_5_scb7_spi_m_select2 {
+				pinmux = <DT_CAT1_PINMUX(2, 5, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p3_5_scb6_spi_m_select2: p3_5_scb6_spi_m_select2 {
+				pinmux = <DT_CAT1_PINMUX(3, 5, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p3_6_scb8_spi_m_select2: p3_6_scb8_spi_m_select2 {
+				pinmux = <DT_CAT1_PINMUX(3, 6, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p5_0_scb5_spi_m_select2: p5_0_scb5_spi_m_select2 {
+				pinmux = <DT_CAT1_PINMUX(5, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p6_5_scb4_spi_m_select2: p6_5_scb4_spi_m_select2 {
+				pinmux = <DT_CAT1_PINMUX(6, 5, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p7_5_scb5_spi_m_select2: p7_5_scb5_spi_m_select2 {
+				pinmux = <DT_CAT1_PINMUX(7, 5, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p10_5_scb4_spi_m_select2: p10_5_scb4_spi_m_select2 {
+				pinmux = <DT_CAT1_PINMUX(10, 5, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p13_5_scb3_spi_m_select2: p13_5_scb3_spi_m_select2 {
+				pinmux = <DT_CAT1_PINMUX(13, 5, HSIOM_SEL_ACT_9)>;
+			};
+			/omit-if-no-ref/ p14_5_scb2_spi_m_select2: p14_5_scb2_spi_m_select2 {
+				pinmux = <DT_CAT1_PINMUX(14, 5, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p16_1_scb9_spi_m_select2: p16_1_scb9_spi_m_select2 {
+				pinmux = <DT_CAT1_PINMUX(16, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p17_6_scb3_spi_m_select2: p17_6_scb3_spi_m_select2 {
+				pinmux = <DT_CAT1_PINMUX(17, 6, HSIOM_SEL_ACT_9)>;
+			};
+			/omit-if-no-ref/ p18_5_scb1_spi_m_select2: p18_5_scb1_spi_m_select2 {
+				pinmux = <DT_CAT1_PINMUX(18, 5, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p20_0_scb2_spi_m_select2: p20_0_scb2_spi_m_select2 {
+				pinmux = <DT_CAT1_PINMUX(20, 0, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p21_0_scb1_spi_m_select2: p21_0_scb1_spi_m_select2 {
+				pinmux = <DT_CAT1_PINMUX(21, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p22_5_scb6_spi_m_select2: p22_5_scb6_spi_m_select2 {
+				pinmux = <DT_CAT1_PINMUX(22, 5, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p23_5_scb7_spi_m_select2: p23_5_scb7_spi_m_select2 {
+				pinmux = <DT_CAT1_PINMUX(23, 5, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p28_5_scb10_spi_m_select2: p28_5_scb10_spi_m_select2 {
+				pinmux = <DT_CAT1_PINMUX(28, 5, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p30_3_scb9_spi_m_select2: p30_3_scb9_spi_m_select2 {
+				pinmux = <DT_CAT1_PINMUX(30, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p32_5_scb10_spi_m_select2: p32_5_scb10_spi_m_select2 {
+				pinmux = <DT_CAT1_PINMUX(32, 5, HSIOM_SEL_ACT_7)>;
+			};
+
+			/* scb_spi_m_select3 */
+			/omit-if-no-ref/ p2_2_scb0_spi_m_select3: p2_2_scb0_spi_m_select3 {
+				pinmux = <DT_CAT1_PINMUX(2, 2, HSIOM_SEL_DS_6)>;
+			};
+			/omit-if-no-ref/ p5_1_scb9_spi_m_select3: p5_1_scb9_spi_m_select3 {
+				pinmux = <DT_CAT1_PINMUX(5, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p6_6_scb4_spi_m_select3: p6_6_scb4_spi_m_select3 {
+				pinmux = <DT_CAT1_PINMUX(6, 6, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p13_6_scb3_spi_m_select3: p13_6_scb3_spi_m_select3 {
+				pinmux = <DT_CAT1_PINMUX(13, 6, HSIOM_SEL_ACT_9)>;
+			};
+			/omit-if-no-ref/ p16_2_scb9_spi_m_select3: p16_2_scb9_spi_m_select3 {
+				pinmux = <DT_CAT1_PINMUX(16, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p18_6_scb1_spi_m_select3: p18_6_scb1_spi_m_select3 {
+				pinmux = <DT_CAT1_PINMUX(18, 6, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p28_6_scb10_spi_m_select3: p28_6_scb10_spi_m_select3 {
+				pinmux = <DT_CAT1_PINMUX(28, 6, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p32_6_scb10_spi_m_select3: p32_6_scb10_spi_m_select3 {
+				pinmux = <DT_CAT1_PINMUX(32, 6, HSIOM_SEL_ACT_7)>;
+			};
+
+			/* scb_spi_s_clk */
+			/omit-if-no-ref/ p0_2_scb0_spi_s_clk: p0_2_scb0_spi_s_clk {
+				pinmux = <DT_CAT1_PINMUX(0, 2, HSIOM_SEL_DS_6)>;
+			};
+			/omit-if-no-ref/ p1_0_scb4_spi_s_clk: p1_0_scb4_spi_s_clk {
+				pinmux = <DT_CAT1_PINMUX(1, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p1_2_scb0_spi_s_clk: p1_2_scb0_spi_s_clk {
+				pinmux = <DT_CAT1_PINMUX(1, 2, HSIOM_SEL_DS_6)>;
+			};
+			/omit-if-no-ref/ p2_2_scb7_spi_s_clk: p2_2_scb7_spi_s_clk {
+				pinmux = <DT_CAT1_PINMUX(2, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p3_2_scb6_spi_s_clk: p3_2_scb6_spi_s_clk {
+				pinmux = <DT_CAT1_PINMUX(3, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p4_2_scb5_spi_s_clk: p4_2_scb5_spi_s_clk {
+				pinmux = <DT_CAT1_PINMUX(4, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p6_2_scb4_spi_s_clk: p6_2_scb4_spi_s_clk {
+				pinmux = <DT_CAT1_PINMUX(6, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p7_2_scb5_spi_s_clk: p7_2_scb5_spi_s_clk {
+				pinmux = <DT_CAT1_PINMUX(7, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p10_2_scb4_spi_s_clk: p10_2_scb4_spi_s_clk {
+				pinmux = <DT_CAT1_PINMUX(10, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p12_2_scb8_spi_s_clk: p12_2_scb8_spi_s_clk {
+				pinmux = <DT_CAT1_PINMUX(12, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p13_2_scb3_spi_s_clk: p13_2_scb3_spi_s_clk {
+				pinmux = <DT_CAT1_PINMUX(13, 2, HSIOM_SEL_ACT_9)>;
+			};
+			/omit-if-no-ref/ p14_2_scb2_spi_s_clk: p14_2_scb2_spi_s_clk {
+				pinmux = <DT_CAT1_PINMUX(14, 2, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p15_2_scb9_spi_s_clk: p15_2_scb9_spi_s_clk {
+				pinmux = <DT_CAT1_PINMUX(15, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p17_3_scb3_spi_s_clk: p17_3_scb3_spi_s_clk {
+				pinmux = <DT_CAT1_PINMUX(17, 3, HSIOM_SEL_ACT_9)>;
+			};
+			/omit-if-no-ref/ p18_2_scb1_spi_s_clk: p18_2_scb1_spi_s_clk {
+				pinmux = <DT_CAT1_PINMUX(18, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p18_3_scb3_spi_s_clk: p18_3_scb3_spi_s_clk {
+				pinmux = <DT_CAT1_PINMUX(18, 3, HSIOM_SEL_ACT_9)>;
+			};
+			/omit-if-no-ref/ p19_2_scb2_spi_s_clk: p19_2_scb2_spi_s_clk {
+				pinmux = <DT_CAT1_PINMUX(19, 2, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p20_5_scb1_spi_s_clk: p20_5_scb1_spi_s_clk {
+				pinmux = <DT_CAT1_PINMUX(20, 5, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p22_2_scb6_spi_s_clk: p22_2_scb6_spi_s_clk {
+				pinmux = <DT_CAT1_PINMUX(22, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p23_2_scb7_spi_s_clk: p23_2_scb7_spi_s_clk {
+				pinmux = <DT_CAT1_PINMUX(23, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p23_6_scb2_spi_s_clk: p23_6_scb2_spi_s_clk {
+				pinmux = <DT_CAT1_PINMUX(23, 6, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p28_2_scb10_spi_s_clk: p28_2_scb10_spi_s_clk {
+				pinmux = <DT_CAT1_PINMUX(28, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p30_0_scb9_spi_s_clk: p30_0_scb9_spi_s_clk {
+				pinmux = <DT_CAT1_PINMUX(30, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p32_2_scb10_spi_s_clk: p32_2_scb10_spi_s_clk {
+				pinmux = <DT_CAT1_PINMUX(32, 2, HSIOM_SEL_ACT_7)>;
+			};
+
+			/* scb_spi_s_miso */
+			/omit-if-no-ref/ p0_0_scb0_spi_s_miso: p0_0_scb0_spi_s_miso {
+				pinmux = <DT_CAT1_PINMUX(0, 0, HSIOM_SEL_DS_6)>;
+			};
+			/omit-if-no-ref/ p0_2_scb4_spi_s_miso: p0_2_scb4_spi_s_miso {
+				pinmux = <DT_CAT1_PINMUX(0, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p1_0_scb0_spi_s_miso: p1_0_scb0_spi_s_miso {
+				pinmux = <DT_CAT1_PINMUX(1, 0, HSIOM_SEL_DS_6)>;
+			};
+			/omit-if-no-ref/ p1_4_scb8_spi_s_miso: p1_4_scb8_spi_s_miso {
+				pinmux = <DT_CAT1_PINMUX(1, 4, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p2_0_scb7_spi_s_miso: p2_0_scb7_spi_s_miso {
+				pinmux = <DT_CAT1_PINMUX(2, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p3_0_scb6_spi_s_miso: p3_0_scb6_spi_s_miso {
+				pinmux = <DT_CAT1_PINMUX(3, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p4_0_scb5_spi_s_miso: p4_0_scb5_spi_s_miso {
+				pinmux = <DT_CAT1_PINMUX(4, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p6_0_scb4_spi_s_miso: p6_0_scb4_spi_s_miso {
+				pinmux = <DT_CAT1_PINMUX(6, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p7_0_scb5_spi_s_miso: p7_0_scb5_spi_s_miso {
+				pinmux = <DT_CAT1_PINMUX(7, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p10_0_scb4_spi_s_miso: p10_0_scb4_spi_s_miso {
+				pinmux = <DT_CAT1_PINMUX(10, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p12_0_scb8_spi_s_miso: p12_0_scb8_spi_s_miso {
+				pinmux = <DT_CAT1_PINMUX(12, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p13_0_scb3_spi_s_miso: p13_0_scb3_spi_s_miso {
+				pinmux = <DT_CAT1_PINMUX(13, 0, HSIOM_SEL_ACT_9)>;
+			};
+			/omit-if-no-ref/ p14_0_scb2_spi_s_miso: p14_0_scb2_spi_s_miso {
+				pinmux = <DT_CAT1_PINMUX(14, 0, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p15_0_scb9_spi_s_miso: p15_0_scb9_spi_s_miso {
+				pinmux = <DT_CAT1_PINMUX(15, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p18_0_scb1_spi_s_miso: p18_0_scb1_spi_s_miso {
+				pinmux = <DT_CAT1_PINMUX(18, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p18_1_scb3_spi_s_miso: p18_1_scb3_spi_s_miso {
+				pinmux = <DT_CAT1_PINMUX(18, 1, HSIOM_SEL_ACT_9)>;
+			};
+			/omit-if-no-ref/ p19_0_scb2_spi_s_miso: p19_0_scb2_spi_s_miso {
+				pinmux = <DT_CAT1_PINMUX(19, 0, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p20_3_scb1_spi_s_miso: p20_3_scb1_spi_s_miso {
+				pinmux = <DT_CAT1_PINMUX(20, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p21_7_scb6_spi_s_miso: p21_7_scb6_spi_s_miso {
+				pinmux = <DT_CAT1_PINMUX(21, 7, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p23_0_scb7_spi_s_miso: p23_0_scb7_spi_s_miso {
+				pinmux = <DT_CAT1_PINMUX(23, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p23_4_scb2_spi_s_miso: p23_4_scb2_spi_s_miso {
+				pinmux = <DT_CAT1_PINMUX(23, 4, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p28_0_scb10_spi_s_miso: p28_0_scb10_spi_s_miso {
+				pinmux = <DT_CAT1_PINMUX(28, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p32_0_scb10_spi_s_miso: p32_0_scb10_spi_s_miso {
+				pinmux = <DT_CAT1_PINMUX(32, 0, HSIOM_SEL_ACT_7)>;
+			};
+
+			/* scb_spi_s_mosi */
+			/omit-if-no-ref/ p0_1_scb0_spi_s_mosi: p0_1_scb0_spi_s_mosi {
+				pinmux = <DT_CAT1_PINMUX(0, 1, HSIOM_SEL_DS_6)>;
+			};
+			/omit-if-no-ref/ p0_3_scb4_spi_s_mosi: p0_3_scb4_spi_s_mosi {
+				pinmux = <DT_CAT1_PINMUX(0, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p1_1_scb0_spi_s_mosi: p1_1_scb0_spi_s_mosi {
+				pinmux = <DT_CAT1_PINMUX(1, 1, HSIOM_SEL_DS_6)>;
+			};
+			/omit-if-no-ref/ p2_1_scb7_spi_s_mosi: p2_1_scb7_spi_s_mosi {
+				pinmux = <DT_CAT1_PINMUX(2, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p3_1_scb6_spi_s_mosi: p3_1_scb6_spi_s_mosi {
+				pinmux = <DT_CAT1_PINMUX(3, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p4_1_scb5_spi_s_mosi: p4_1_scb5_spi_s_mosi {
+				pinmux = <DT_CAT1_PINMUX(4, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p6_1_scb4_spi_s_mosi: p6_1_scb4_spi_s_mosi {
+				pinmux = <DT_CAT1_PINMUX(6, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p7_1_scb5_spi_s_mosi: p7_1_scb5_spi_s_mosi {
+				pinmux = <DT_CAT1_PINMUX(7, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p10_1_scb4_spi_s_mosi: p10_1_scb4_spi_s_mosi {
+				pinmux = <DT_CAT1_PINMUX(10, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p12_1_scb8_spi_s_mosi: p12_1_scb8_spi_s_mosi {
+				pinmux = <DT_CAT1_PINMUX(12, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p13_1_scb3_spi_s_mosi: p13_1_scb3_spi_s_mosi {
+				pinmux = <DT_CAT1_PINMUX(13, 1, HSIOM_SEL_ACT_9)>;
+			};
+			/omit-if-no-ref/ p14_1_scb2_spi_s_mosi: p14_1_scb2_spi_s_mosi {
+				pinmux = <DT_CAT1_PINMUX(14, 1, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p15_1_scb9_spi_s_mosi: p15_1_scb9_spi_s_mosi {
+				pinmux = <DT_CAT1_PINMUX(15, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p18_1_scb1_spi_s_mosi: p18_1_scb1_spi_s_mosi {
+				pinmux = <DT_CAT1_PINMUX(18, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p18_2_scb3_spi_s_mosi: p18_2_scb3_spi_s_mosi {
+				pinmux = <DT_CAT1_PINMUX(18, 2, HSIOM_SEL_ACT_9)>;
+			};
+			/omit-if-no-ref/ p19_1_scb2_spi_s_mosi: p19_1_scb2_spi_s_mosi {
+				pinmux = <DT_CAT1_PINMUX(19, 1, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p20_4_scb1_spi_s_mosi: p20_4_scb1_spi_s_mosi {
+				pinmux = <DT_CAT1_PINMUX(20, 4, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p22_1_scb6_spi_s_mosi: p22_1_scb6_spi_s_mosi {
+				pinmux = <DT_CAT1_PINMUX(22, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p23_1_scb7_spi_s_mosi: p23_1_scb7_spi_s_mosi {
+				pinmux = <DT_CAT1_PINMUX(23, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p23_5_scb2_spi_s_mosi: p23_5_scb2_spi_s_mosi {
+				pinmux = <DT_CAT1_PINMUX(23, 5, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p28_1_scb10_spi_s_mosi: p28_1_scb10_spi_s_mosi {
+				pinmux = <DT_CAT1_PINMUX(28, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p32_1_scb10_spi_s_mosi: p32_1_scb10_spi_s_mosi {
+				pinmux = <DT_CAT1_PINMUX(32, 1, HSIOM_SEL_ACT_7)>;
+			};
+
+			/* scb_spi_s_select0 */
+			/omit-if-no-ref/ p0_3_scb0_spi_s_select0: p0_3_scb0_spi_s_select0 {
+				pinmux = <DT_CAT1_PINMUX(0, 3, HSIOM_SEL_DS_6)>;
+			};
+			/omit-if-no-ref/ p1_1_scb4_spi_s_select0: p1_1_scb4_spi_s_select0 {
+				pinmux = <DT_CAT1_PINMUX(1, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p1_3_scb0_spi_s_select0: p1_3_scb0_spi_s_select0 {
+				pinmux = <DT_CAT1_PINMUX(1, 3, HSIOM_SEL_DS_6)>;
+			};
+			/omit-if-no-ref/ p2_3_scb7_spi_s_select0: p2_3_scb7_spi_s_select0 {
+				pinmux = <DT_CAT1_PINMUX(2, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p2_6_scb8_spi_s_select0: p2_6_scb8_spi_s_select0 {
+				pinmux = <DT_CAT1_PINMUX(2, 6, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p3_3_scb6_spi_s_select0: p3_3_scb6_spi_s_select0 {
+				pinmux = <DT_CAT1_PINMUX(3, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p4_3_scb5_spi_s_select0: p4_3_scb5_spi_s_select0 {
+				pinmux = <DT_CAT1_PINMUX(4, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p6_3_scb4_spi_s_select0: p6_3_scb4_spi_s_select0 {
+				pinmux = <DT_CAT1_PINMUX(6, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p7_3_scb5_spi_s_select0: p7_3_scb5_spi_s_select0 {
+				pinmux = <DT_CAT1_PINMUX(7, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p10_3_scb4_spi_s_select0: p10_3_scb4_spi_s_select0 {
+				pinmux = <DT_CAT1_PINMUX(10, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p12_3_scb8_spi_s_select0: p12_3_scb8_spi_s_select0 {
+				pinmux = <DT_CAT1_PINMUX(12, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p13_3_scb3_spi_s_select0: p13_3_scb3_spi_s_select0 {
+				pinmux = <DT_CAT1_PINMUX(13, 3, HSIOM_SEL_ACT_9)>;
+			};
+			/omit-if-no-ref/ p14_3_scb2_spi_s_select0: p14_3_scb2_spi_s_select0 {
+				pinmux = <DT_CAT1_PINMUX(14, 3, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p15_3_scb9_spi_s_select0: p15_3_scb9_spi_s_select0 {
+				pinmux = <DT_CAT1_PINMUX(15, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p17_4_scb3_spi_s_select0: p17_4_scb3_spi_s_select0 {
+				pinmux = <DT_CAT1_PINMUX(17, 4, HSIOM_SEL_ACT_9)>;
+			};
+			/omit-if-no-ref/ p18_3_scb1_spi_s_select0: p18_3_scb1_spi_s_select0 {
+				pinmux = <DT_CAT1_PINMUX(18, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p18_4_scb3_spi_s_select0: p18_4_scb3_spi_s_select0 {
+				pinmux = <DT_CAT1_PINMUX(18, 4, HSIOM_SEL_ACT_9)>;
+			};
+			/omit-if-no-ref/ p19_3_scb2_spi_s_select0: p19_3_scb2_spi_s_select0 {
+				pinmux = <DT_CAT1_PINMUX(19, 3, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p20_6_scb1_spi_s_select0: p20_6_scb1_spi_s_select0 {
+				pinmux = <DT_CAT1_PINMUX(20, 6, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p22_3_scb6_spi_s_select0: p22_3_scb6_spi_s_select0 {
+				pinmux = <DT_CAT1_PINMUX(22, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p23_3_scb7_spi_s_select0: p23_3_scb7_spi_s_select0 {
+				pinmux = <DT_CAT1_PINMUX(23, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p23_7_scb2_spi_s_select0: p23_7_scb2_spi_s_select0 {
+				pinmux = <DT_CAT1_PINMUX(23, 7, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p28_3_scb10_spi_s_select0: p28_3_scb10_spi_s_select0 {
+				pinmux = <DT_CAT1_PINMUX(28, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p30_1_scb9_spi_s_select0: p30_1_scb9_spi_s_select0 {
+				pinmux = <DT_CAT1_PINMUX(30, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p32_3_scb10_spi_s_select0: p32_3_scb10_spi_s_select0 {
+				pinmux = <DT_CAT1_PINMUX(32, 3, HSIOM_SEL_ACT_7)>;
+			};
+
+			/* scb_spi_s_select1 */
+			/omit-if-no-ref/ p2_0_scb0_spi_s_select1: p2_0_scb0_spi_s_select1 {
+				pinmux = <DT_CAT1_PINMUX(2, 0, HSIOM_SEL_DS_6)>;
+			};
+			/omit-if-no-ref/ p2_4_scb7_spi_s_select1: p2_4_scb7_spi_s_select1 {
+				pinmux = <DT_CAT1_PINMUX(2, 4, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p2_7_scb8_spi_s_select1: p2_7_scb8_spi_s_select1 {
+				pinmux = <DT_CAT1_PINMUX(2, 7, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p3_4_scb6_spi_s_select1: p3_4_scb6_spi_s_select1 {
+				pinmux = <DT_CAT1_PINMUX(3, 4, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p4_4_scb5_spi_s_select1: p4_4_scb5_spi_s_select1 {
+				pinmux = <DT_CAT1_PINMUX(4, 4, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p6_4_scb4_spi_s_select1: p6_4_scb4_spi_s_select1 {
+				pinmux = <DT_CAT1_PINMUX(6, 4, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p7_4_scb5_spi_s_select1: p7_4_scb5_spi_s_select1 {
+				pinmux = <DT_CAT1_PINMUX(7, 4, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p10_4_scb4_spi_s_select1: p10_4_scb4_spi_s_select1 {
+				pinmux = <DT_CAT1_PINMUX(10, 4, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p12_4_scb8_spi_s_select1: p12_4_scb8_spi_s_select1 {
+				pinmux = <DT_CAT1_PINMUX(12, 4, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p13_4_scb3_spi_s_select1: p13_4_scb3_spi_s_select1 {
+				pinmux = <DT_CAT1_PINMUX(13, 4, HSIOM_SEL_ACT_9)>;
+			};
+			/omit-if-no-ref/ p14_4_scb2_spi_s_select1: p14_4_scb2_spi_s_select1 {
+				pinmux = <DT_CAT1_PINMUX(14, 4, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p16_0_scb9_spi_s_select1: p16_0_scb9_spi_s_select1 {
+				pinmux = <DT_CAT1_PINMUX(16, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p17_5_scb3_spi_s_select1: p17_5_scb3_spi_s_select1 {
+				pinmux = <DT_CAT1_PINMUX(17, 5, HSIOM_SEL_ACT_9)>;
+			};
+			/omit-if-no-ref/ p18_4_scb1_spi_s_select1: p18_4_scb1_spi_s_select1 {
+				pinmux = <DT_CAT1_PINMUX(18, 4, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p19_4_scb2_spi_s_select1: p19_4_scb2_spi_s_select1 {
+				pinmux = <DT_CAT1_PINMUX(19, 4, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p20_7_scb1_spi_s_select1: p20_7_scb1_spi_s_select1 {
+				pinmux = <DT_CAT1_PINMUX(20, 7, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p22_4_scb6_spi_s_select1: p22_4_scb6_spi_s_select1 {
+				pinmux = <DT_CAT1_PINMUX(22, 4, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p23_4_scb7_spi_s_select1: p23_4_scb7_spi_s_select1 {
+				pinmux = <DT_CAT1_PINMUX(23, 4, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p28_4_scb10_spi_s_select1: p28_4_scb10_spi_s_select1 {
+				pinmux = <DT_CAT1_PINMUX(28, 4, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p30_2_scb9_spi_s_select1: p30_2_scb9_spi_s_select1 {
+				pinmux = <DT_CAT1_PINMUX(30, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p32_4_scb10_spi_s_select1: p32_4_scb10_spi_s_select1 {
+				pinmux = <DT_CAT1_PINMUX(32, 4, HSIOM_SEL_ACT_7)>;
+			};
+
+			/* scb_spi_s_select2 */
+			/omit-if-no-ref/ p2_1_scb0_spi_s_select2: p2_1_scb0_spi_s_select2 {
+				pinmux = <DT_CAT1_PINMUX(2, 1, HSIOM_SEL_DS_6)>;
+			};
+			/omit-if-no-ref/ p2_5_scb7_spi_s_select2: p2_5_scb7_spi_s_select2 {
+				pinmux = <DT_CAT1_PINMUX(2, 5, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p3_5_scb6_spi_s_select2: p3_5_scb6_spi_s_select2 {
+				pinmux = <DT_CAT1_PINMUX(3, 5, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p3_6_scb8_spi_s_select2: p3_6_scb8_spi_s_select2 {
+				pinmux = <DT_CAT1_PINMUX(3, 6, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p5_0_scb5_spi_s_select2: p5_0_scb5_spi_s_select2 {
+				pinmux = <DT_CAT1_PINMUX(5, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p6_5_scb4_spi_s_select2: p6_5_scb4_spi_s_select2 {
+				pinmux = <DT_CAT1_PINMUX(6, 5, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p7_5_scb5_spi_s_select2: p7_5_scb5_spi_s_select2 {
+				pinmux = <DT_CAT1_PINMUX(7, 5, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p10_5_scb4_spi_s_select2: p10_5_scb4_spi_s_select2 {
+				pinmux = <DT_CAT1_PINMUX(10, 5, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p13_5_scb3_spi_s_select2: p13_5_scb3_spi_s_select2 {
+				pinmux = <DT_CAT1_PINMUX(13, 5, HSIOM_SEL_ACT_9)>;
+			};
+			/omit-if-no-ref/ p14_5_scb2_spi_s_select2: p14_5_scb2_spi_s_select2 {
+				pinmux = <DT_CAT1_PINMUX(14, 5, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p16_1_scb9_spi_s_select2: p16_1_scb9_spi_s_select2 {
+				pinmux = <DT_CAT1_PINMUX(16, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p17_6_scb3_spi_s_select2: p17_6_scb3_spi_s_select2 {
+				pinmux = <DT_CAT1_PINMUX(17, 6, HSIOM_SEL_ACT_9)>;
+			};
+			/omit-if-no-ref/ p18_5_scb1_spi_s_select2: p18_5_scb1_spi_s_select2 {
+				pinmux = <DT_CAT1_PINMUX(18, 5, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p20_0_scb2_spi_s_select2: p20_0_scb2_spi_s_select2 {
+				pinmux = <DT_CAT1_PINMUX(20, 0, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p21_0_scb1_spi_s_select2: p21_0_scb1_spi_s_select2 {
+				pinmux = <DT_CAT1_PINMUX(21, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p22_5_scb6_spi_s_select2: p22_5_scb6_spi_s_select2 {
+				pinmux = <DT_CAT1_PINMUX(22, 5, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p23_5_scb7_spi_s_select2: p23_5_scb7_spi_s_select2 {
+				pinmux = <DT_CAT1_PINMUX(23, 5, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p28_5_scb10_spi_s_select2: p28_5_scb10_spi_s_select2 {
+				pinmux = <DT_CAT1_PINMUX(28, 5, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p30_3_scb9_spi_s_select2: p30_3_scb9_spi_s_select2 {
+				pinmux = <DT_CAT1_PINMUX(30, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p32_5_scb10_spi_s_select2: p32_5_scb10_spi_s_select2 {
+				pinmux = <DT_CAT1_PINMUX(32, 5, HSIOM_SEL_ACT_7)>;
+			};
+
+			/* scb_spi_s_select3 */
+			/omit-if-no-ref/ p2_2_scb0_spi_s_select3: p2_2_scb0_spi_s_select3 {
+				pinmux = <DT_CAT1_PINMUX(2, 2, HSIOM_SEL_DS_6)>;
+			};
+			/omit-if-no-ref/ p5_1_scb9_spi_s_select3: p5_1_scb9_spi_s_select3 {
+				pinmux = <DT_CAT1_PINMUX(5, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p6_6_scb4_spi_s_select3: p6_6_scb4_spi_s_select3 {
+				pinmux = <DT_CAT1_PINMUX(6, 6, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p13_6_scb3_spi_s_select3: p13_6_scb3_spi_s_select3 {
+				pinmux = <DT_CAT1_PINMUX(13, 6, HSIOM_SEL_ACT_9)>;
+			};
+			/omit-if-no-ref/ p16_2_scb9_spi_s_select3: p16_2_scb9_spi_s_select3 {
+				pinmux = <DT_CAT1_PINMUX(16, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p18_6_scb1_spi_s_select3: p18_6_scb1_spi_s_select3 {
+				pinmux = <DT_CAT1_PINMUX(18, 6, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p28_6_scb10_spi_s_select3: p28_6_scb10_spi_s_select3 {
+				pinmux = <DT_CAT1_PINMUX(28, 6, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p32_6_scb10_spi_s_select3: p32_6_scb10_spi_s_select3 {
+				pinmux = <DT_CAT1_PINMUX(32, 6, HSIOM_SEL_ACT_7)>;
+			};
+
+			/* scb_uart_cts */
+			/omit-if-no-ref/ p0_3_scb0_uart_cts: p0_3_scb0_uart_cts {
+				pinmux = <DT_CAT1_PINMUX(0, 3, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p2_3_scb7_uart_cts: p2_3_scb7_uart_cts {
+				pinmux = <DT_CAT1_PINMUX(2, 3, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p2_6_scb8_uart_cts: p2_6_scb8_uart_cts {
+				pinmux = <DT_CAT1_PINMUX(2, 6, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p3_3_scb6_uart_cts: p3_3_scb6_uart_cts {
+				pinmux = <DT_CAT1_PINMUX(3, 3, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p4_3_scb5_uart_cts: p4_3_scb5_uart_cts {
+				pinmux = <DT_CAT1_PINMUX(4, 3, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p6_3_scb4_uart_cts: p6_3_scb4_uart_cts {
+				pinmux = <DT_CAT1_PINMUX(6, 3, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p7_3_scb5_uart_cts: p7_3_scb5_uart_cts {
+				pinmux = <DT_CAT1_PINMUX(7, 3, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p10_3_scb4_uart_cts: p10_3_scb4_uart_cts {
+				pinmux = <DT_CAT1_PINMUX(10, 3, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p12_3_scb8_uart_cts: p12_3_scb8_uart_cts {
+				pinmux = <DT_CAT1_PINMUX(12, 3, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p13_3_scb3_uart_cts: p13_3_scb3_uart_cts {
+				pinmux = <DT_CAT1_PINMUX(13, 3, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p14_3_scb2_uart_cts: p14_3_scb2_uart_cts {
+				pinmux = <DT_CAT1_PINMUX(14, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p15_3_scb9_uart_cts: p15_3_scb9_uart_cts {
+				pinmux = <DT_CAT1_PINMUX(15, 3, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p17_4_scb3_uart_cts: p17_4_scb3_uart_cts {
+				pinmux = <DT_CAT1_PINMUX(17, 4, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p18_3_scb1_uart_cts: p18_3_scb1_uart_cts {
+				pinmux = <DT_CAT1_PINMUX(18, 3, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p19_3_scb2_uart_cts: p19_3_scb2_uart_cts {
+				pinmux = <DT_CAT1_PINMUX(19, 3, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p20_6_scb1_uart_cts: p20_6_scb1_uart_cts {
+				pinmux = <DT_CAT1_PINMUX(20, 6, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p22_3_scb6_uart_cts: p22_3_scb6_uart_cts {
+				pinmux = <DT_CAT1_PINMUX(22, 3, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p23_3_scb7_uart_cts: p23_3_scb7_uart_cts {
+				pinmux = <DT_CAT1_PINMUX(23, 3, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p28_3_scb10_uart_cts: p28_3_scb10_uart_cts {
+				pinmux = <DT_CAT1_PINMUX(28, 3, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p30_1_scb9_uart_cts: p30_1_scb9_uart_cts {
+				pinmux = <DT_CAT1_PINMUX(30, 1, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p32_3_scb10_uart_cts: p32_3_scb10_uart_cts {
+				pinmux = <DT_CAT1_PINMUX(32, 3, HSIOM_SEL_ACT_5)>;
+			};
+
+			/* scb_uart_rts */
+			/omit-if-no-ref/ p0_2_scb0_uart_rts: p0_2_scb0_uart_rts {
+				pinmux = <DT_CAT1_PINMUX(0, 2, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p2_2_scb7_uart_rts: p2_2_scb7_uart_rts {
+				pinmux = <DT_CAT1_PINMUX(2, 2, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p3_2_scb6_uart_rts: p3_2_scb6_uart_rts {
+				pinmux = <DT_CAT1_PINMUX(3, 2, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p4_2_scb5_uart_rts: p4_2_scb5_uart_rts {
+				pinmux = <DT_CAT1_PINMUX(4, 2, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p6_2_scb4_uart_rts: p6_2_scb4_uart_rts {
+				pinmux = <DT_CAT1_PINMUX(6, 2, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p7_2_scb5_uart_rts: p7_2_scb5_uart_rts {
+				pinmux = <DT_CAT1_PINMUX(7, 2, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p10_2_scb4_uart_rts: p10_2_scb4_uart_rts {
+				pinmux = <DT_CAT1_PINMUX(10, 2, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p12_2_scb8_uart_rts: p12_2_scb8_uart_rts {
+				pinmux = <DT_CAT1_PINMUX(12, 2, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p13_2_scb3_uart_rts: p13_2_scb3_uart_rts {
+				pinmux = <DT_CAT1_PINMUX(13, 2, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p14_2_scb2_uart_rts: p14_2_scb2_uart_rts {
+				pinmux = <DT_CAT1_PINMUX(14, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p15_2_scb9_uart_rts: p15_2_scb9_uart_rts {
+				pinmux = <DT_CAT1_PINMUX(15, 2, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p17_3_scb3_uart_rts: p17_3_scb3_uart_rts {
+				pinmux = <DT_CAT1_PINMUX(17, 3, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p18_2_scb1_uart_rts: p18_2_scb1_uart_rts {
+				pinmux = <DT_CAT1_PINMUX(18, 2, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p19_2_scb2_uart_rts: p19_2_scb2_uart_rts {
+				pinmux = <DT_CAT1_PINMUX(19, 2, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p20_5_scb1_uart_rts: p20_5_scb1_uart_rts {
+				pinmux = <DT_CAT1_PINMUX(20, 5, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p22_2_scb6_uart_rts: p22_2_scb6_uart_rts {
+				pinmux = <DT_CAT1_PINMUX(22, 2, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p23_2_scb7_uart_rts: p23_2_scb7_uart_rts {
+				pinmux = <DT_CAT1_PINMUX(23, 2, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p28_2_scb10_uart_rts: p28_2_scb10_uart_rts {
+				pinmux = <DT_CAT1_PINMUX(28, 2, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p30_0_scb9_uart_rts: p30_0_scb9_uart_rts {
+				pinmux = <DT_CAT1_PINMUX(30, 0, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p32_2_scb10_uart_rts: p32_2_scb10_uart_rts {
+				pinmux = <DT_CAT1_PINMUX(32, 2, HSIOM_SEL_ACT_5)>;
+			};
+
+			/* scb_uart_rx */
+			/omit-if-no-ref/ p0_0_scb0_uart_rx: p0_0_scb0_uart_rx {
+				pinmux = <DT_CAT1_PINMUX(0, 0, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p1_4_scb8_uart_rx: p1_4_scb8_uart_rx {
+				pinmux = <DT_CAT1_PINMUX(1, 4, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p2_0_scb7_uart_rx: p2_0_scb7_uart_rx {
+				pinmux = <DT_CAT1_PINMUX(2, 0, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p3_0_scb6_uart_rx: p3_0_scb6_uart_rx {
+				pinmux = <DT_CAT1_PINMUX(3, 0, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p4_0_scb5_uart_rx: p4_0_scb5_uart_rx {
+				pinmux = <DT_CAT1_PINMUX(4, 0, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p6_0_scb4_uart_rx: p6_0_scb4_uart_rx {
+				pinmux = <DT_CAT1_PINMUX(6, 0, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p7_0_scb5_uart_rx: p7_0_scb5_uart_rx {
+				pinmux = <DT_CAT1_PINMUX(7, 0, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p10_0_scb4_uart_rx: p10_0_scb4_uart_rx {
+				pinmux = <DT_CAT1_PINMUX(10, 0, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p12_0_scb8_uart_rx: p12_0_scb8_uart_rx {
+				pinmux = <DT_CAT1_PINMUX(12, 0, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p13_0_scb3_uart_rx: p13_0_scb3_uart_rx {
+				pinmux = <DT_CAT1_PINMUX(13, 0, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p14_0_scb2_uart_rx: p14_0_scb2_uart_rx {
+				pinmux = <DT_CAT1_PINMUX(14, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p15_0_scb9_uart_rx: p15_0_scb9_uart_rx {
+				pinmux = <DT_CAT1_PINMUX(15, 0, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p17_1_scb3_uart_rx: p17_1_scb3_uart_rx {
+				pinmux = <DT_CAT1_PINMUX(17, 1, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p18_0_scb1_uart_rx: p18_0_scb1_uart_rx {
+				pinmux = <DT_CAT1_PINMUX(18, 0, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p19_0_scb2_uart_rx: p19_0_scb2_uart_rx {
+				pinmux = <DT_CAT1_PINMUX(19, 0, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p20_3_scb1_uart_rx: p20_3_scb1_uart_rx {
+				pinmux = <DT_CAT1_PINMUX(20, 3, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p21_7_scb6_uart_rx: p21_7_scb6_uart_rx {
+				pinmux = <DT_CAT1_PINMUX(21, 7, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p23_0_scb7_uart_rx: p23_0_scb7_uart_rx {
+				pinmux = <DT_CAT1_PINMUX(23, 0, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p28_0_scb10_uart_rx: p28_0_scb10_uart_rx {
+				pinmux = <DT_CAT1_PINMUX(28, 0, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p32_0_scb10_uart_rx: p32_0_scb10_uart_rx {
+				pinmux = <DT_CAT1_PINMUX(32, 0, HSIOM_SEL_ACT_5)>;
+			};
+
+			/* scb_uart_tx */
+			/omit-if-no-ref/ p0_1_scb0_uart_tx: p0_1_scb0_uart_tx {
+				pinmux = <DT_CAT1_PINMUX(0, 1, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p2_1_scb7_uart_tx: p2_1_scb7_uart_tx {
+				pinmux = <DT_CAT1_PINMUX(2, 1, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p3_1_scb6_uart_tx: p3_1_scb6_uart_tx {
+				pinmux = <DT_CAT1_PINMUX(3, 1, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p4_1_scb5_uart_tx: p4_1_scb5_uart_tx {
+				pinmux = <DT_CAT1_PINMUX(4, 1, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p6_1_scb4_uart_tx: p6_1_scb4_uart_tx {
+				pinmux = <DT_CAT1_PINMUX(6, 1, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p7_1_scb5_uart_tx: p7_1_scb5_uart_tx {
+				pinmux = <DT_CAT1_PINMUX(7, 1, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p10_1_scb4_uart_tx: p10_1_scb4_uart_tx {
+				pinmux = <DT_CAT1_PINMUX(10, 1, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p12_1_scb8_uart_tx: p12_1_scb8_uart_tx {
+				pinmux = <DT_CAT1_PINMUX(12, 1, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p13_1_scb3_uart_tx: p13_1_scb3_uart_tx {
+				pinmux = <DT_CAT1_PINMUX(13, 1, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p14_1_scb2_uart_tx: p14_1_scb2_uart_tx {
+				pinmux = <DT_CAT1_PINMUX(14, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p15_1_scb9_uart_tx: p15_1_scb9_uart_tx {
+				pinmux = <DT_CAT1_PINMUX(15, 1, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p17_2_scb3_uart_tx: p17_2_scb3_uart_tx {
+				pinmux = <DT_CAT1_PINMUX(17, 2, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p18_1_scb1_uart_tx: p18_1_scb1_uart_tx {
+				pinmux = <DT_CAT1_PINMUX(18, 1, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p19_1_scb2_uart_tx: p19_1_scb2_uart_tx {
+				pinmux = <DT_CAT1_PINMUX(19, 1, HSIOM_SEL_ACT_7)>;
+			};
+			/omit-if-no-ref/ p20_4_scb1_uart_tx: p20_4_scb1_uart_tx {
+				pinmux = <DT_CAT1_PINMUX(20, 4, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p22_1_scb6_uart_tx: p22_1_scb6_uart_tx {
+				pinmux = <DT_CAT1_PINMUX(22, 1, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p23_1_scb7_uart_tx: p23_1_scb7_uart_tx {
+				pinmux = <DT_CAT1_PINMUX(23, 1, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p28_1_scb10_uart_tx: p28_1_scb10_uart_tx {
+				pinmux = <DT_CAT1_PINMUX(28, 1, HSIOM_SEL_ACT_5)>;
+			};
+			/omit-if-no-ref/ p32_1_scb10_uart_tx: p32_1_scb10_uart_tx {
+				pinmux = <DT_CAT1_PINMUX(32, 1, HSIOM_SEL_ACT_5)>;
+			};
+
+			/* sdhc_card_cmd */
+			/omit-if-no-ref/ p6_3_sdhc0_card_cmd: p6_3_sdhc0_card_cmd {
+				pinmux = <DT_CAT1_PINMUX(6, 3, HSIOM_SEL_ACT_13)>;
+			};
+			/omit-if-no-ref/ p24_3_sdhc0_card_cmd: p24_3_sdhc0_card_cmd {
+				pinmux = <DT_CAT1_PINMUX(24, 3, HSIOM_SEL_ACT_13)>;
+			};
+
+			/* sdhc_card_dat_3to0 */
+			/omit-if-no-ref/ p7_1_sdhc0_card_dat_3to0: p7_1_sdhc0_card_dat_3to0 {
+				pinmux = <DT_CAT1_PINMUX(7, 1, HSIOM_SEL_ACT_13)>;
+			};
+			/omit-if-no-ref/ p7_2_sdhc0_card_dat_3to0: p7_2_sdhc0_card_dat_3to0 {
+				pinmux = <DT_CAT1_PINMUX(7, 2, HSIOM_SEL_ACT_13)>;
+			};
+			/omit-if-no-ref/ p7_3_sdhc0_card_dat_3to0: p7_3_sdhc0_card_dat_3to0 {
+				pinmux = <DT_CAT1_PINMUX(7, 3, HSIOM_SEL_ACT_13)>;
+			};
+			/omit-if-no-ref/ p7_4_sdhc0_card_dat_3to0: p7_4_sdhc0_card_dat_3to0 {
+				pinmux = <DT_CAT1_PINMUX(7, 4, HSIOM_SEL_ACT_13)>;
+			};
+			/omit-if-no-ref/ p25_0_sdhc0_card_dat_3to0: p25_0_sdhc0_card_dat_3to0 {
+				pinmux = <DT_CAT1_PINMUX(25, 0, HSIOM_SEL_ACT_13)>;
+			};
+			/omit-if-no-ref/ p25_1_sdhc0_card_dat_3to0: p25_1_sdhc0_card_dat_3to0 {
+				pinmux = <DT_CAT1_PINMUX(25, 1, HSIOM_SEL_ACT_13)>;
+			};
+			/omit-if-no-ref/ p25_2_sdhc0_card_dat_3to0: p25_2_sdhc0_card_dat_3to0 {
+				pinmux = <DT_CAT1_PINMUX(25, 2, HSIOM_SEL_ACT_13)>;
+			};
+			/omit-if-no-ref/ p25_3_sdhc0_card_dat_3to0: p25_3_sdhc0_card_dat_3to0 {
+				pinmux = <DT_CAT1_PINMUX(25, 3, HSIOM_SEL_ACT_13)>;
+			};
+
+			/* sdhc_card_dat_7to4 */
+			/omit-if-no-ref/ p7_5_sdhc0_card_dat_7to4: p7_5_sdhc0_card_dat_7to4 {
+				pinmux = <DT_CAT1_PINMUX(7, 5, HSIOM_SEL_ACT_13)>;
+			};
+			/omit-if-no-ref/ p8_0_sdhc0_card_dat_7to4: p8_0_sdhc0_card_dat_7to4 {
+				pinmux = <DT_CAT1_PINMUX(8, 0, HSIOM_SEL_ACT_13)>;
+			};
+			/omit-if-no-ref/ p8_1_sdhc0_card_dat_7to4: p8_1_sdhc0_card_dat_7to4 {
+				pinmux = <DT_CAT1_PINMUX(8, 1, HSIOM_SEL_ACT_13)>;
+			};
+			/omit-if-no-ref/ p8_2_sdhc0_card_dat_7to4: p8_2_sdhc0_card_dat_7to4 {
+				pinmux = <DT_CAT1_PINMUX(8, 2, HSIOM_SEL_ACT_13)>;
+			};
+			/omit-if-no-ref/ p25_4_sdhc0_card_dat_7to4: p25_4_sdhc0_card_dat_7to4 {
+				pinmux = <DT_CAT1_PINMUX(25, 4, HSIOM_SEL_ACT_13)>;
+			};
+			/omit-if-no-ref/ p25_5_sdhc0_card_dat_7to4: p25_5_sdhc0_card_dat_7to4 {
+				pinmux = <DT_CAT1_PINMUX(25, 5, HSIOM_SEL_ACT_13)>;
+			};
+			/omit-if-no-ref/ p25_6_sdhc0_card_dat_7to4: p25_6_sdhc0_card_dat_7to4 {
+				pinmux = <DT_CAT1_PINMUX(25, 6, HSIOM_SEL_ACT_13)>;
+			};
+			/omit-if-no-ref/ p25_7_sdhc0_card_dat_7to4: p25_7_sdhc0_card_dat_7to4 {
+				pinmux = <DT_CAT1_PINMUX(25, 7, HSIOM_SEL_ACT_13)>;
+			};
+
+			/* sdhc_card_detect_n */
+			/omit-if-no-ref/ p6_5_sdhc0_card_detect_n: p6_5_sdhc0_card_detect_n {
+				pinmux = <DT_CAT1_PINMUX(6, 5, HSIOM_SEL_ACT_13)>;
+			};
+			/omit-if-no-ref/ p24_0_sdhc0_card_detect_n: p24_0_sdhc0_card_detect_n {
+				pinmux = <DT_CAT1_PINMUX(24, 0, HSIOM_SEL_ACT_13)>;
+			};
+
+			/* sdhc_card_if_pwr_en */
+			/omit-if-no-ref/ p7_0_sdhc0_card_if_pwr_en: p7_0_sdhc0_card_if_pwr_en {
+				pinmux = <DT_CAT1_PINMUX(7, 0, HSIOM_SEL_ACT_13)>;
+			};
+			/omit-if-no-ref/ p24_4_sdhc0_card_if_pwr_en: p24_4_sdhc0_card_if_pwr_en {
+				pinmux = <DT_CAT1_PINMUX(24, 4, HSIOM_SEL_ACT_13)>;
+			};
+
+			/* sdhc_card_mech_write_prot */
+			/omit-if-no-ref/
+			p6_2_sdhc0_card_mech_write_prot: p6_2_sdhc0_card_mech_write_prot {
+				pinmux = <DT_CAT1_PINMUX(6, 2, HSIOM_SEL_ACT_13)>;
+			};
+			/omit-if-no-ref/
+			p24_1_sdhc0_card_mech_write_prot: p24_1_sdhc0_card_mech_write_prot {
+				pinmux = <DT_CAT1_PINMUX(24, 1, HSIOM_SEL_ACT_13)>;
+			};
+
+			/* sdhc_clk_card */
+			/omit-if-no-ref/ p6_4_sdhc0_clk_card: p6_4_sdhc0_clk_card {
+				pinmux = <DT_CAT1_PINMUX(6, 4, HSIOM_SEL_ACT_13)>;
+			};
+			/omit-if-no-ref/ p24_2_sdhc0_clk_card: p24_2_sdhc0_clk_card {
+				pinmux = <DT_CAT1_PINMUX(24, 2, HSIOM_SEL_ACT_13)>;
+			};
+
+			/* CAN */
+
+			/omit-if-no-ref/ p0_2_can0_0_tx: p0_2_can0_0_tx {
+				pinmux = <DT_CAT1_PINMUX(0, 2, HSIOM_SEL_ACT_9)>;
+				drive-push-pull;
+			};
+			/omit-if-no-ref/ p0_3_can0_0_rx: p0_3_can0_0_rx {
+				pinmux = <DT_CAT1_PINMUX(0, 3, HSIOM_SEL_ACT_9)>;
+				input-enable;
+			};
+
+			/* smif-qspi*/
+
+			/omit-if-no-ref/ p6_3_smif0_clk: p6_3_smif0_clk {
+				pinmux = <DT_CAT1_PINMUX(6, 3, HSIOM_SEL_ACT_11)>;
+			};
+
+			/omit-if-no-ref/ p6_5_smif0_sel0: p6_5_smif0_sel0 {
+				pinmux = <DT_CAT1_PINMUX(6, 5, HSIOM_SEL_ACT_11)>;
+			};
+
+			/omit-if-no-ref/ p7_1_smif0_data0: p7_1_smif0_data0 {
+				pinmux = <DT_CAT1_PINMUX(7, 1, HSIOM_SEL_ACT_11)>;
+			};
+
+			/omit-if-no-ref/ p7_2_smif0_data1: p7_2_smif0_data1 {
+				pinmux = <DT_CAT1_PINMUX(7, 2, HSIOM_SEL_ACT_11)>;
+			};
+
+			/omit-if-no-ref/ p7_3_smif0_data2: p7_3_smif0_data2 {
+				pinmux = <DT_CAT1_PINMUX(7, 3, HSIOM_SEL_ACT_11)>;
+			};
+
+			/omit-if-no-ref/ p7_4_smif0_data3: p7_4_smif0_data3 {
+				pinmux = <DT_CAT1_PINMUX(7, 4, HSIOM_SEL_ACT_11)>;
+			};
+
+
+			/* ethernet */
+
+			/omit-if-no-ref/ p26_0_eth_ref_clk: p26_0_eth_ref_clk {
+				pinmux = <DT_CAT1_PINMUX(26, 0, HSIOM_SEL_ACT_15)>;
+				input-enable;
+			};
+			/omit-if-no-ref/ p26_2_eth_txd_0: p26_2_eth_txd_0 {
+				pinmux = <DT_CAT1_PINMUX(26, 2, HSIOM_SEL_ACT_15)>;
+				drive-push-pull;
+			};
+			/omit-if-no-ref/ p26_3_eth_txd_1: p26_3_eth_txd_1 {
+				pinmux = <DT_CAT1_PINMUX(26, 3, HSIOM_SEL_ACT_15)>;
+				drive-push-pull;
+			};
+			/omit-if-no-ref/ p26_4_eth_txd_2: p26_4_eth_txd_2 {
+				pinmux = <DT_CAT1_PINMUX(26, 4, HSIOM_SEL_ACT_15)>;
+				drive-push-pull;
+			};
+			/omit-if-no-ref/ p26_5_eth_txd_3: p26_5_eth_txd_3 {
+				pinmux = <DT_CAT1_PINMUX(26, 5, HSIOM_SEL_ACT_15)>;
+				drive-push-pull;
+			};
+			/omit-if-no-ref/ p26_6_eth_tx_clk: p26_6_eth_tx_clk {
+				pinmux = <DT_CAT1_PINMUX(26, 6, HSIOM_SEL_ACT_15)>;
+				drive-push-pull;
+			};
+			/omit-if-no-ref/ p26_1_eth_tx_en: p26_1_eth_tx_en {
+				pinmux = <DT_CAT1_PINMUX(26, 1, HSIOM_SEL_ACT_15)>;
+				drive-push-pull;
+			};
+			/omit-if-no-ref/ p26_7_eth_rxd_0: p26_7_eth_rxd_0 {
+				pinmux = <DT_CAT1_PINMUX(26, 7, HSIOM_SEL_ACT_15)>;
+				input-enable;
+			};
+			/omit-if-no-ref/ p27_0_eth_rxd_1: p27_0_eth_rxd_1 {
+				pinmux = <DT_CAT1_PINMUX(27, 0, HSIOM_SEL_ACT_15)>;
+				input-enable;
+			};
+			/omit-if-no-ref/ p27_1_eth_rxd_2: p27_1_eth_rxd_2 {
+				pinmux = <DT_CAT1_PINMUX(27, 1, HSIOM_SEL_ACT_15)>;
+				input-enable;
+			};
+			/omit-if-no-ref/ p27_2_eth_rxd_3: p27_2_eth_rxd_3 {
+				pinmux = <DT_CAT1_PINMUX(27, 2, HSIOM_SEL_ACT_15)>;
+				input-enable;
+			};
+			/omit-if-no-ref/ p27_3_eth_rx_clk: p27_3_eth_rx_clk {
+				pinmux = <DT_CAT1_PINMUX(27, 3, HSIOM_SEL_ACT_15)>;
+				input-enable;
+			};
+			/omit-if-no-ref/ p27_4_eth_rx_ctl: p27_4_eth_rx_ctl {
+				pinmux = <DT_CAT1_PINMUX(27, 4, HSIOM_SEL_ACT_15)>;
+				input-enable;
+			};
+			/omit-if-no-ref/ p27_5_eth_mdc: p27_5_eth_mdc {
+				pinmux = <DT_CAT1_PINMUX(27, 5, HSIOM_SEL_ACT_15)>;
+				drive-push-pull;
+			};
+			/omit-if-no-ref/ p27_6_eth_mdio: p27_6_eth_mdio {
+				pinmux = <DT_CAT1_PINMUX(27, 6, HSIOM_SEL_ACT_15)>;
+				drive-push-pull;
+				input-enable;
+			};
+		};
+	};
+};
+
+&gpio_prt1 {
+	ngpios = <5>;
+};
+
+&gpio_prt4 {
+	ngpios = <5>;
+};
+
+&gpio_prt22 {
+	ngpios = <7>;
+};

--- a/dts/arm/infineon/cat1c/traveo2-8m/cyt4bfbche.dtsi
+++ b/dts/arm/infineon/cat1c/traveo2-8m/cyt4bfbche.dtsi
@@ -1,3 +1,3 @@
 #include <arm/infineon/cat1c/traveo2-8m/system_clocks.dtsi>
 #include <arm/infineon/cat1c/traveo2-8m/cyt4bf.dtsi>
-#include <arm/infineon/cat1c/xmc7200/xmc7200.272-bga.dtsi>
+#include <arm/infineon/cat1c/traveo2-8m/cyt4bfb-pinctrl.dtsi>

--- a/samples/subsys/ipc/openamp/boards/kit_t2g_b_h_evk_cyt4bfbche_m0p.conf
+++ b/samples/subsys/ipc/openamp/boards/kit_t2g_b_h_evk_cyt4bfbche_m0p.conf
@@ -1,0 +1,2 @@
+# OpenAMP Host configuration for kit_t2g_b_h_evk (CM0P)
+CONFIG_MBOX=y

--- a/samples/subsys/ipc/openamp/boards/kit_t2g_b_h_evk_cyt4bfbche_m0p.overlay
+++ b/samples/subsys/ipc/openamp/boards/kit_t2g_b_h_evk_cyt4bfbche_m0p.overlay
@@ -2,7 +2,14 @@
  * Copyright (c) 2026 Infineon Technologies AG
  * SPDX-License-Identifier: Apache-2.0
  *
- * OpenAMP IPC overlay for kit_t2g_b_h_evk (CYT4BFBCHE) - Host (CM7_0)
+ * OpenAMP IPC overlay for kit_t2g_b_h_evk (CYT4BFBCHE) - Host (CM0P) with CM7_0 remote
+ *
+ * CURRENTLY CONFIGURED FOR: M0P ↔ M7_0
+ *
+ * To switch to M7_1 remote:
+ * 1. In Kconfig.sysbuild, change:
+ *    default "kit_t2g_b_h_evk/cyt4bfbche/m7_1" if $(BOARD) = "kit_t2g_b_h_evk/cyt4bfbche/m0p"
+ * 2. Copy content from kit_t2g_b_h_evk_cyt4bfbche_m0p_for_m7_1.overlay to this file
  */
 
 / {
@@ -23,9 +30,9 @@
 		#size-cells = <1>;
 
 		/*
-		 * Shared memory region for IPC between CM7_0 and CM7_1
-		 * Located at the end of sram_m7_1 region to avoid overlap
-		 * Address: 0x2807C000 (M7_1 end - 16KB)
+		 * Shared memory region for IPC between CM0P and CM7_1
+		 * Located at the end of sram_m7_0 region
+		 * Address: 0x2803C000 (M7_0 end - 16KB)
 		 * Size: 16KB (0x4000)
 		 */
 		ipc_shm0: memory@2807c000 {
@@ -39,6 +46,4 @@
 	status = "okay";
 };
 
-&m7_1 {
-	status = "okay";
-};
+

--- a/samples/subsys/ipc/openamp/remote/boards/kit_t2g_b_h_evk_cyt4bfbche_m7_1.overlay
+++ b/samples/subsys/ipc/openamp/remote/boards/kit_t2g_b_h_evk_cyt4bfbche_m7_1.overlay
@@ -1,8 +1,6 @@
 /*
  * Copyright (c) 2026 Infineon Technologies AG
  * SPDX-License-Identifier: Apache-2.0
- *
- * OpenAMP IPC overlay for kit_t2g_b_h_evk (CYT4BFBCHE) - Remote (CM7_1)
  */
 
 / {
@@ -23,14 +21,12 @@
 		#size-cells = <1>;
 
 		/*
-		 * Shared memory region for IPC between CM7_0 and M7_1
-		 * Must match the host overlay exactly
-		 * Address: 0x28080000 (in sram2)
+		 * Address: 0x2807C000
 		 * Size: 16KB (0x4000)
 		 */
-		ipc_shm0: memory@28080000 {
+		ipc_shm0: memory@2807c000 {
 			compatible = "mmio-sram";
-			reg = <0x28080000 0x4000>;
+			reg = <0x2807c000 0x4000>;
 		};
 	};
 };
@@ -38,3 +34,4 @@
 &mbox {
 	status = "okay";
 };
+


### PR DESCRIPTION
1. Removed ethernet and smif node from kit_t2g_b_h_evk_common.dtsi
2. Add OpenAMP remote and host config/overlay for M0P.
3. Validate IPC communication between M0P & M7_1, M7_0 & M7_1.