### PR TITLE
Infineon: cyt2bl: enable peripheral support and clock updates for kit_t2g_b_e_lite

### DIFF
--- a/boards/infineon/kit_t2g_b_e_lite/kit_t2g_b_e_lite.dts
+++ b/boards/infineon/kit_t2g_b_e_lite/kit_t2g_b_e_lite.dts
@@ -7,210 +7,229 @@
 
 
 / {
-    model = "Infineon Traveo II Body Entry LiteKit" ;
-    compatible = "infineon,tvii4m" ;
+	model = "Infineon Traveo II Body Entry LiteKit" ;
+	compatible = "infineon,tvii4m" ;
 
-        chosen {
-                zephyr,sram = &sram0;
-                zephyr,flash = &code_flash0;
-                zephyr,console = &uart0;
-                zephyr,shell-uart = &uart0;
-                zephyr,canbus = &can0;
-                
-        };
+		chosen {
+				zephyr,sram = &sram0;
+				zephyr,flash = &code_flash0;
+				zephyr,console = &uart0;
+				zephyr,shell-uart = &uart0;
+				zephyr,canbus = &can0;
 
-    aliases {
-            led0 = &user_led0;
-            led1 = &user_led1;
-            led2 = &user_led2;
-            sw0 = &user_bt0;
-            sw1 = &user_bt1;
-            watchdog0 = &watchdog0;
-            dma0 = &dma0;
-            i2c0 = &scb4;
-    };
-    
-    leds{
-        compatible = "gpio-leds";
+		};
 
-        user_led0: led0 {
-            label = "LED_1";
-            gpios = <&gpio_prt5 0 GPIO_ACTIVE_HIGH>;
-        };
-
-        user_led1: led1 {
-            label = "LED_2";
-            gpios = <&gpio_prt5 1 GPIO_ACTIVE_HIGH>;
-        };
-
-        user_led2: led2 {
-            label = "LED_3";
-            gpios = <&gpio_prt5 2 GPIO_ACTIVE_HIGH>;
-        };
-       
-    };
-
-    gpio_keys {
-                compatible = "gpio-keys";
-
-                user_bt0: user_btn0 {
-                    label = "SW_0";
-                    gpios = <&gpio_prt5 3(GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
-                    zephyr,code = <INPUT_KEY_0>;
-                };
-
-                user_bt1: user_btn1 {
-                    label = "SW_1";
-                    gpios = <&gpio_prt17 0(GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
-                    zephyr,code = <INPUT_KEY_1>;
-                };
-    };
-
-
-
-};
-
-&p0_0_scb0_uart_rx {
-	input-enable;
-};
-
-&p0_1_scb0_uart_tx {
-	drive-push-pull;
-};
-
-&p6_1_scb4_i2c_sda{
-    drive-open-drain;
-    input-enable;
-};
-
-&p6_2_scb4_i2c_scl{
-    drive-open-drain;
-    input-enable;    
-};
-
-
-
-&watchdog0 {
-    status = "okay";
-};
-
-&dma0 {
-	status = "okay";
-};
-
-uart0: &scb0 {
-	compatible = "infineon,cat1-uart-pdl";
-	status = "okay";
-	current-speed = <115200>;
-    clocks = <&clk_hf0>;
-    ifx,peri-group = <IFX_PERI_GRP_INST_SEL(0, 0)>;
-    ifx,peri-clk = <0x001E>;
-    ifx,peri-div = <1>; /* 16-bit divider */
-    ifx,peri-div-inst = <3>;
-
-	/* UART pins */
-	pinctrl-0  = <&p0_1_scb0_uart_tx &p0_0_scb0_uart_rx>;
-	pinctrl-names = "default";
-};
-
-spi1: &scb3 {
-    compatible = "infineon,cat1-spi-pdl";
-    status = "okay";
-
-    #address-cells = <1>;
-    #size-cells = <0>;
-
-    /* SPI pins */
-    pinctrl-0 = <&p13_0_scb3_spi_m_miso &p13_1_scb3_spi_m_mosi &p13_2_scb3_spi_m_clk>;
-    pinctrl-names = "default";
-    cs-gpios = <&gpio_prt13 3 GPIO_ACTIVE_LOW>;
-
-    ifx,peri-group = <IFX_PERI_GRP_INST_SEL(1, 0)>;
-    ifx,peri-clk = <0x0108>;
-    ifx,peri-div = <1>; /* 16-bit divider */
-    ifx,peri-div-inst = <3>;
-
-	w25q128jvsq2449_spi: spi-nor-flash@0 {
-		compatible = "jedec,spi-nor";
-		status = "okay";
-		reg = <0>;
-        spi-max-frequency = <8000000>;
-		size = <DT_SIZE_M(128)>; /* 64 Mbits */
-		jedec-id = [ef 40 18];
+	aliases {
+			led0 = &user_led0;
+			led1 = &user_led1;
+			led2 = &user_led2;
+			sw0 = &user_bt0;
+			sw1 = &user_bt1;
+			watchdog0 = &watchdog0;
+			dma0 = &dma0;
+			i2c0 = &scb4;
 	};
-};
 
-i2c0: &scb4 {
-    compatible = "infineon,cat1-i2c-pdl";
-    status = "okay";
+	leds {
+		compatible = "gpio-leds";
 
-    #address-cells = <1>;
-    #size-cells = <0>;
+		user_led0: led0 {
+			label = "LED_1";
+			gpios = <&gpio_prt5 0 GPIO_ACTIVE_HIGH>;
+		};
 
-    /* I2C pins */
-    pinctrl-0 = <&p6_1_scb4_i2c_sda &p6_2_scb4_i2c_scl>;
-    pinctrl-names = "default";
+		user_led1: led1 {
+			label = "LED_2";
+			gpios = <&gpio_prt5 1 GPIO_ACTIVE_HIGH>;
+		};
 
-    clocks = <&clk_hf0>;
-    ifx,peri-group = <IFX_PERI_GRP_INST_SEL(0, 0)>;
-    ifx,peri-clk = <0x0022>;
-    ifx,peri-div = <0>; /* 8-bit divider */
-    ifx,peri-div-inst = <1>;
-};
+		user_led2: led2 {
+			label = "LED_3";
+			gpios = <&gpio_prt5 2 GPIO_ACTIVE_HIGH>;
+		};
+
+	};
+
+	gpio_keys {
+				compatible = "gpio-keys";
+
+				user_bt0: user_btn0 {
+					label = "SW_0";
+					gpios = <&gpio_prt5 3(GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+					zephyr,code = <INPUT_KEY_0>;
+				};
+
+				user_bt1: user_btn1 {
+					label = "SW_1";
+					gpios = <&gpio_prt17 0(GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+					zephyr,code = <INPUT_KEY_1>;
+				};
+	};
 
 
-can0: &can0_0 {
-    status = "okay";
-    compatible = "infineon,cat1-can";
-    clocks = <&clk_hf0>;
-    clock-frequency = <40000000>;
-    ifx,peri-group = <IFX_PERI_GRP_INST_SEL(1, 0)>;
-    ifx,peri-clk = <0x0006>;
-    ifx,peri-div = <3>; /* 24-bit divider */
-    ifx,peri-div-inst = <0>;
 
-    pinctrl-0 = <&p2_0_can0_0_tx &p2_1_can0_0_rx>;
-    pinctrl-names = "default";
-};
+	};
 
-adc0: &adc0 {
-       status = "okay";
-	    clocks = <&clk_hf0>;
-       clock-frequency = <10670000>;
-       ifx,peri-group = <IFX_PERI_GRP_INST_SEL(0, 0)>;
-       ifx,peri-clk = <0x001C>;
-       ifx,peri-div = <1>; /* 8-bit divider */
-       ifx,peri-div-inst = <2>;
-	   #io-channel-cells = <1>;
+	&p0_0_scb0_uart_rx {
+		input-enable;
+	};
+
+	&p0_1_scb0_uart_tx {
+		drive-push-pull;
+	};
+
+	&p6_1_scb4_i2c_sda {
+		drive-open-drain;
+		input-enable;
+	};
+
+	&p6_2_scb4_i2c_scl {
+		drive-open-drain;
+		input-enable;
+	};
+
+	&p13_0_scb3_spi_m_miso {
+		input-enable;
+	};
+
+	&p13_1_scb3_spi_m_mosi {
+		drive-push-pull;
+	};
+
+	 &p13_2_scb3_spi_m_clk {
+		drive-push-pull;
+	 };
+
+	&watchdog0 {
+		status = "okay";
+	};
+
+	&dma0 {
+		status = "okay";
+	};
+
+
+
+	uart0: &scb0 {
+		compatible = "infineon,cat1-uart-pdl";
+		status = "okay";
+		current-speed = <115200>;
+		clocks = <&clk_hf0>;
+		ifx,peri-group = <IFX_PERI_GRP_INST_SEL(0, 0)>;
+		ifx,peri-clk = <0x001E>;
+		ifx,peri-div = <0>; /* 16-bit divider */
+		ifx,peri-div-inst = <0>;
+
+		/* UART pins */
+		pinctrl-0  = <&p0_1_scb0_uart_tx &p0_0_scb0_uart_rx>;
+		pinctrl-names = "default";
+	};
+
+	spi1: &scb3 {
+		compatible = "infineon,cat1-spi-pdl";
+		status = "okay";
+
 		#address-cells = <1>;
-   		#size-cells = <0>;
-};
+		#size-cells = <0>;
 
-&gpio_prt0 {
+		/* SPI pins */
+		pinctrl-0 = <&p13_0_scb3_spi_m_miso &p13_1_scb3_spi_m_mosi &p13_2_scb3_spi_m_clk>;
+		pinctrl-names = "default";
+		cs-gpios = <&gpio_prt13 3 GPIO_ACTIVE_LOW>;
+
+		ifx,peri-group = <IFX_PERI_GRP_INST_SEL(1, 0)>;
+		ifx,peri-clk = <0x0021>;
+		ifx,peri-div = <1>; /* 16-bit divider */
+		ifx,peri-div-inst = <3>;
+
+		w25q128jvsq2449_spi: spi-nor-flash@0 {
+			compatible = "jedec,spi-nor";
+			status = "okay";
+			reg = <0>;
+			spi-max-frequency = <8000000>;
+			size = <DT_SIZE_M(128)>; /* 64 Mbits */
+			jedec-id = [ef 40 18];
+		};
+	};
+
+	i2c0: &scb4 {
+		compatible = "infineon,cat1-i2c-pdl";
+		status = "okay";
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		/* I2C pins */
+		pinctrl-0 = <&p6_1_scb4_i2c_sda &p6_2_scb4_i2c_scl>;
+		pinctrl-names = "default";
+
+		clocks = <&clk_hf0>;
+		ifx,peri-group = <IFX_PERI_GRP_INST_SEL(0, 0)>;
+		ifx,peri-clk = <0x0022>;
+		ifx,peri-div = <0>; /* 8-bit divider */
+		ifx,peri-div-inst = <1>;
+	};
+
+
+	can0: &can0_0 {
+		status = "okay";
+		compatible = "infineon,cat1-can";
+		clocks = <&clk_hf0>;
+		clock-frequency = <40000000>;
+		ifx,peri-group = <IFX_PERI_GRP_INST_SEL(0, 0)>;
+		ifx,peri-clk = <0x0006>;
+		ifx,peri-div = <3>; /* 24-bit divider */
+		ifx,peri-div-inst = <0>;
+
+		pinctrl-0 = <&p2_0_can0_0_tx &p2_1_can0_0_rx>;
+		pinctrl-names = "default";
+	};
+
+	adc0: &adc0 {
+		status = "okay";
+		clocks = <&clk_hf0>;
+		clock-frequency = <10670000>;
+		ifx,peri-group = <IFX_PERI_GRP_INST_SEL(0, 0)>;
+		ifx,peri-clk = <0x0026>;
+		ifx,peri-div = <1>; /* 8-bit divider */
+		ifx,peri-div-inst = <2>;
+		#io-channel-cells = <1>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	&gpio_prt0 {
+		status = "okay";
+	};
+
+	&gpio_prt13 {
+		status = "okay";
+	};
+
+	&gpio_prt5 {
+		status = "okay";
+	};
+
+	&gpio_prt17 {
+		status = "okay";
+	};
+
+	&gpio_prt18 {
+		status = "okay";
+	};
+
+	&clk_eco {
 	status = "okay";
-};
+	clock-frequency = <16000000>;
+	};
 
-&gpio_prt5 {
-	status = "okay";
-};
+	&pll0 {
+		status = "okay";
+	};
 
-&gpio_prt17 {
-	status = "okay";
-};
+	&clk_hf2 {
+		status = "okay";
 
-&gpio_prt18 {
-	status = "okay";
-};
-
-&clk_eco {
-status = "okay";
-clock-frequency = <16000000>;
-};
-
-&clk_hf2
-{
-    status = "okay";
-    
-};
+	};
 
 

--- a/dts/arm/infineon/cat1a/cyt2bl/cyt2bl.100-lqfp.dtsi
+++ b/dts/arm/infineon/cat1a/cyt2bl/cyt2bl.100-lqfp.dtsi
@@ -13,14 +13,14 @@
 
 / {
 
-        soc {
-                /delete-node/ gpio@40310080; // gpio_prt1
-                /delete-node/ gpio@40310200; // gpio_prt4
-                /delete-node/ gpio@40310480; // gpio_prt9
-                /delete-node/ gpio@40310500; // gpio_prt10
-                /delete-node/ gpio@40310780; // gpio_prt15
-                /delete-node/ gpio@40310800; // gpio_prt16
-                /delete-node/ gpio@40310A00; // gpio_prt20
+		soc {
+				/delete-node/ gpio@40310080; // gpio_prt1
+				/delete-node/ gpio@40310200; // gpio_prt4
+				/delete-node/ gpio@40310480; // gpio_prt9
+				/delete-node/ gpio@40310500; // gpio_prt10
+				/delete-node/ gpio@40310780; // gpio_prt15
+				/delete-node/ gpio@40310800; // gpio_prt16
+				/delete-node/ gpio@40310A00; // gpio_prt20
 				pinctrl: pinctrl@40300000 {
 					/omit-if-no-ref/ p0_0_scb0_uart_rx: p0_0_scb0_uart_rx {
 								pinmux = <DT_CAT1_PINMUX(0, 0,	HSIOM_SEL_ACT_5)>;
@@ -37,10 +37,10 @@
 					/omit-if-no-ref/ p2_0_scb7_uart_rx: p2_0_scb7_uart_rx {
 								pinmux = <DT_CAT1_PINMUX(2, 0,	HSIOM_SEL_ACT_5)>;
 					};
-                    /omit-if-no-ref/ p2_0_scb7_uart_rx: p2_1_scb7_uart_tx {
+					/omit-if-no-ref/ p2_0_scb7_uart_rx: p2_1_scb7_uart_tx {
 								pinmux = <DT_CAT1_PINMUX(2, 1,	HSIOM_SEL_ACT_5)>;
 					};
-                    /omit-if-no-ref/ p2_1_scb7_uart_rts: p2_1_scb0_uart_rts {
+					/omit-if-no-ref/ p2_1_scb7_uart_rts: p2_1_scb0_uart_rts {
 								pinmux = <DT_CAT1_PINMUX(2, 1,	HSIOM_SEL_ACT_5)>;
 					};
 					/omit-if-no-ref/ p2_3_scb0_uart_cts: p2_3_scb0_uart_cts {
@@ -99,86 +99,86 @@
 					/omit-if-no-ref/ p6_1_scb4_i2c_sda: p6_1_scb4_i2c_sda {
 								pinmux = <DT_CAT1_PINMUX(6, 1, HSIOM_SEL_ACT_6)>;
 					};
-					
+
 					/omit-if-no-ref/ p6_2_scb4_i2c_scl: p6_2_scb4_i2c_scl {
 								pinmux = <DT_CAT1_PINMUX(6, 2, HSIOM_SEL_ACT_6)>;
 					};
 
-					
-			
-                            };
-    };
-};
-
-&gpio_prt0 {
-	    ngpios = <4>;
-};
-
-&gpio_prt2 {
-	    ngpios = <4>;
-};
-
-&gpio_prt3 {
-	    ngpios = <2>;
-};
-
-&gpio_prt5 {
-	    ngpios = <4>;
-};
-
-&gpio_prt6 {
-	    ngpios = <6>;
-};
-
-&gpio_prt7 {
-	    ngpios = <6>;
-};
-
-&gpio_prt8 {
-	    ngpios = <3>;
-};
-
-&gpio_prt11 {
-	    ngpios = <3>;
-};
-
-&gpio_prt12 {
-	    ngpios = <5>;
-};
-
-&gpio_prt13 {
-	    ngpios = <8>;
-};
-
-&gpio_prt14 {
-	    ngpios = <4>;
-};
-
-&gpio_prt17 {
-	    ngpios = <3>;
-};
-
-&gpio_prt18 {
-	    ngpios = <8>;
-};
 
 
-&gpio_prt19 {
-	    ngpios = <4>;
+							};
+	};
 };
 
-&gpio_prt21 {
-	    ngpios = <6>;
-};
+		&gpio_prt0 {
+				ngpios = <4>;
+		};
 
-&gpio_prt22 {
-	    ngpios = <4>;
-};
+		&gpio_prt2 {
+				ngpios = <4>;
+		};
 
-&gpio_prt23 {
-	    ngpios = <5>;
-};
+		&gpio_prt3 {
+				ngpios = <2>;
+		};
 
-&nvic {
-	arm,num-irq-priority-bits = <3>;
-};
+		&gpio_prt5 {
+				ngpios = <4>;
+		};
+
+		&gpio_prt6 {
+				ngpios = <6>;
+		};
+
+		&gpio_prt7 {
+				ngpios = <6>;
+		};
+
+		&gpio_prt8 {
+				ngpios = <3>;
+		};
+
+		&gpio_prt11 {
+				ngpios = <3>;
+		};
+
+		&gpio_prt12 {
+				ngpios = <5>;
+		};
+
+		&gpio_prt13 {
+				ngpios = <8>;
+		};
+
+		&gpio_prt14 {
+				ngpios = <4>;
+		};
+
+		&gpio_prt17 {
+				ngpios = <3>;
+		};
+
+		&gpio_prt18 {
+				ngpios = <8>;
+		};
+
+
+		&gpio_prt19 {
+				ngpios = <4>;
+		};
+
+		&gpio_prt21 {
+				ngpios = <6>;
+		};
+
+		&gpio_prt22 {
+				ngpios = <4>;
+		};
+
+		&gpio_prt23 {
+				ngpios = <5>;
+		};
+
+		&nvic {
+			arm,num-irq-priority-bits = <3>;
+		};

--- a/dts/arm/infineon/cat1a/cyt2bl/cyt2bl.dtsi
+++ b/dts/arm/infineon/cat1a/cyt2bl/cyt2bl.dtsi
@@ -7,88 +7,88 @@
 
 
 
-#include <mem.h>   
+#include <mem.h>
 
 / {
 
-cpus{
+	cpus{
 
-    #address-cells = <1>;
-    #size-cells =<0>;
+		#address-cells = <1>;
+		#size-cells =<0>;
 
-        cpu@0 {
-			device_type = "cpu";
-			compatible = "arm,cortex-m0+";
-			reg = <0>;
+			cpu@0 {
+				device_type = "cpu";
+				compatible = "arm,cortex-m0+";
+				reg = <0>;
+			};
+
+			cpu@1 {
+				device_type = "cpu";
+				compatible = "arm,cortex-m4f";
+				reg = <1>;
+			};
+
 		};
 
-		cpu@1 {
-			device_type = "cpu";
-			compatible = "arm,cortex-m4f";
-			reg = <1>;
-		};
-	
-    };
+	flash_controller:flash-controller@0x40240000 {
 
-flash_controller:flash-controller@0x40240000 {
+		compatible = "infineon,flash-controller";
+		reg = <0x40240000 0x10000>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		status = "okay";
 
-    compatible = "infineon,flash-controller";
-	reg = <0x40240000 0x10000>;
-	#address-cells = <1>;
-	#size-cells = <1>;
-    status = "okay";
+		/* Code flash - Large sector (32KB Sectors) */
+		code_flash0: flash@10000000 {
+				compatible = "soc-nv-flash";
+				reg = <0x10000000  DT_SIZE_K(4032)>;
+				write-block-size = <512>;
+				erase-block-size = <32768>;
+			};
 
-    /* Code flash - Large sector (32KB Sectors) */
-    code_flash0: flash@10000000 {
-			compatible = "soc-nv-flash";
-			reg = <0x10000000  DT_SIZE_K(4032)>;
-			write-block-size = <512>;
-			erase-block-size = <32768>; 
-		};
-    
-    /* Code flash - Small sector (8KB Sectors) */
-    code_flash1: flash@0x103F0000 {
-            compatible = "soc-nv-flash";
-            reg = <0x103F0000 DT_SIZE_K(128)>;
-            write-block-size = <512>;
-            erase-block-size = <8192>;
-        };
+		/* Code flash - Small sector (8KB Sectors) */
+		code_flash1: flash@0x103F0000 {
+				compatible = "soc-nv-flash";
+				reg = <0x103F0000 DT_SIZE_K(128)>;
+				write-block-size = <512>;
+				erase-block-size = <8192>;
+			};
 
 
-    /* Work flash - Large sector (2KB Sectors) */
-		work_flash0: flash@14000000 {
-			compatible = "soc-nv-flash";
-			reg = <0x14000000 DT_SIZE_K(96)>;
-			write-block-size = <512>;
-			erase-block-size = <2048>;
-		};      
+		/* Work flash - Large sector (2KB Sectors) */
+			work_flash0: flash@14000000 {
+				compatible = "soc-nv-flash";
+				reg = <0x14000000 DT_SIZE_K(96)>;
+				write-block-size = <512>;
+				erase-block-size = <2048>;
+			};
 
-      /* Work flash - Small sector (128B Sectors) */
-        work_flash1: flash@0x14018000 {
-            compatible = "soc-nv-flash";
-            reg = <0x14018000 DT_SIZE_K(32)>;
-            write-block-size = <64>;
-            erase-block-size = <128>;
-        };
-};
-
-
-    sram0: memory@8000000 {
-		    compatible = "mmio-sram";
-		    reg = <0x8000000 0x40000>;
-	};
-
-    sram1: memory@8040000 {
-		    compatible = "mmio-sram";
-		    reg = <0x08040000 0x20000>;
+		  /* Work flash - Small sector (128B Sectors) */
+			work_flash1: flash@0x14018000 {
+				compatible = "soc-nv-flash";
+				reg = <0x14018000 DT_SIZE_K(32)>;
+				write-block-size = <64>;
+				erase-block-size = <128>;
+			};
 	};
 
 
+			sram0: memory@8000000 {
+					compatible = "mmio-sram";
+					reg = <0x8000000 0x40000>;
+			};
 
-soc {
-		        clocking: clocking {
-            compatible = "infineon,cat1-clocking";
-        };
+			sram1: memory@8040000 {
+					compatible = "mmio-sram";
+					reg = <0x08040000 0x20000>;
+			};
+
+
+
+	soc {
+				clocking: clocking {
+			compatible = "infineon,cat1-clocking";
+		};
 		pinctrl: pinctrl@40300000 {
 			compatible = "infineon,cat1-pinctrl";
 			reg = <0x40300000 0x10000>;
@@ -103,120 +103,120 @@ soc {
 			status = "disabled";
 		};
 
-           gpio_prt0: gpio@40310000 {
+		   gpio_prt0: gpio@40310000 {
 			compatible = "infineon,cat1-gpio";
 			reg = <0x40310000 0x80>;
-			interrupts = <21 6>;
+			system-interrupts = <21 6>;
 			gpio-controller;
 			ngpios = <8>;
 			status = "disabled";
 			#gpio-cells = <2>;
 		};
 
-        gpio_prt1: gpio@40310080 {
+		gpio_prt1: gpio@40310080 {
 			compatible = "infineon,cat1-gpio";
 			reg = <0x40310080 0x80>;
-			interrupts = <22 6>;
+			system-interrupts = <22 6>;
 			gpio-controller;
 			ngpios = <8>;
 			status = "disabled";
 			#gpio-cells = <2>;
 		};
 
-        gpio_prt2: gpio@40310100 {
+		gpio_prt2: gpio@40310100 {
 			compatible = "infineon,cat1-gpio";
 			reg = <0x40310100 0x80>;
-			interrupts = <23 6>;
+			system-interrupts = <23 6>;
 			gpio-controller;
 			ngpios = <8>;
 			status = "disabled";
 			#gpio-cells = <2>;
 		};
 
-        gpio_prt3: gpio@40310180 {
+		gpio_prt3: gpio@40310180 {
 			compatible = "infineon,cat1-gpio";
 			reg = <0x40310180 0x80>;
-			interrupts = <24 6>;
+			system-interrupts = <24 6>;
 			gpio-controller;
 			ngpios = <8>;
 			status = "disabled";
 			#gpio-cells = <2>;
 		};
 
-        gpio_prt4: gpio@40310200 {
+		gpio_prt4: gpio@40310200 {
 			compatible = "infineon,cat1-gpio";
 			reg = <0x40310200 0x80>;
-			interrupts = <25 6>;
+			system-interrupts = <25 6>;
 			gpio-controller;
 			ngpios = <8>;
 			status = "disabled";
 			#gpio-cells = <2>;
 		};
 
-        gpio_prt5: gpio@40310280 {
+		gpio_prt5: gpio@40310280 {
 			compatible = "infineon,cat1-gpio";
 			reg = <0x40310280 0x80>;
-			interrupts = <26 6>;
+			system-interrupts = <26 6>;
 			gpio-controller;
 			ngpios = <8>;
 			status = "disabled";
 			#gpio-cells = <2>;
 		};
 
-        gpio_prt6: gpio@40310300 {
+		gpio_prt6: gpio@40310300 {
 			compatible = "infineon,cat1-gpio";
 			reg = <0x40310300 0x80>;
-			interrupts = <27 6>;
+			system-interrupts = <27 6>;
 			gpio-controller;
 			ngpios = <8>;
 			status = "disabled";
 			#gpio-cells = <2>;
 		};
 
-        gpio_prt7: gpio@40310380 {
+		gpio_prt7: gpio@40310380 {
 			compatible = "infineon,cat1-gpio";
 			reg = <0x40310380 0x80>;
-			interrupts = <28 6>;
+			system-interrupts = <28 6>;
 			gpio-controller;
 			ngpios = <8>;
 			status = "disabled";
 			#gpio-cells = <2>;
 		};
 
-        gpio_prt8: gpio@40310400 {
+		gpio_prt8: gpio@40310400 {
 			compatible = "infineon,cat1-gpio";
 			reg = <0x40310400 0x80>;
-			interrupts = <29 6>;
+			system-interrupts = <29 6>;
 			gpio-controller;
 			ngpios = <8>;
 			status = "disabled";
 			#gpio-cells = <2>;
 		};
 
-        gpio_prt9: gpio@40310480 {
+		gpio_prt9: gpio@40310480 {
 			compatible = "infineon,cat1-gpio";
 			reg = <0x40310480 0x80>;
-			interrupts = <30 6>;
+			system-interrupts = <30 6>;
 			gpio-controller;
 			ngpios = <8>;
 			status = "disabled";
 			#gpio-cells = <2>;
 		};
 
-        gpio_prt10: gpio@40310500 {
+		gpio_prt10: gpio@40310500 {
 			compatible = "infineon,cat1-gpio";
 			reg = <0x40310500 0x80>;
-			interrupts = <31 6>;
+			system-interrupts = <31 6>;
 			gpio-controller;
 			ngpios = <8>;
 			status = "disabled";
 			#gpio-cells = <2>;
 		};
 
-        gpio_prt11: gpio@40310580 {
+		gpio_prt11: gpio@40310580 {
 			compatible = "infineon,cat1-gpio";
 			reg = <0x40310580 0x80>;
-			interrupts = <32 6>;
+			system-interrupts = <32 6>;
 			gpio-controller;
 			ngpios = <8>;
 			status = "disabled";
@@ -224,120 +224,120 @@ soc {
 		};
 
 
-        gpio_prt12: gpio@40310600 {
+		gpio_prt12: gpio@40310600 {
 			compatible = "infineon,cat1-gpio";
 			reg = <0x40310600 0x80>;
-			interrupts = <33 6>;
+			system-interrupts = <33 6>;
 			gpio-controller;
 			ngpios = <8>;
 			status = "disabled";
 			#gpio-cells = <2>;
 		};
 
-        gpio_prt13: gpio@40310680 {
+		gpio_prt13: gpio@40310680 {
 			compatible = "infineon,cat1-gpio";
 			reg = <0x40310680 0x80>;
-			interrupts = <34 6>;
+			system-interrupts = <34 6>;
 			gpio-controller;
 			ngpios = <8>;
 			status = "disabled";
 			#gpio-cells = <2>;
 		};
 
-        gpio_prt14: gpio@40310700 {
+		gpio_prt14: gpio@40310700 {
 			compatible = "infineon,cat1-gpio";
 			reg = <0x40310700 0x80>;
-			interrupts = <35 6>;
+			system-interrupts = <35 6>;
 			gpio-controller;
 			ngpios = <8>;
 			status = "disabled";
 			#gpio-cells = <2>;
 		};
 
-        gpio_prt15: gpio@40310780 {
+		gpio_prt15: gpio@40310780 {
 			compatible = "infineon,cat1-gpio";
 			reg = <0x40310780 0x80>;
-			interrupts = <36 6>;
+			system-interrupts = <36 6>;
 			gpio-controller;
 			ngpios = <8>;
 			status = "disabled";
 			#gpio-cells = <2>;
 		};
 
-        gpio_prt16: gpio@40310800 {
+		gpio_prt16: gpio@40310800 {
 			compatible = "infineon,cat1-gpio";
 			reg = <0x40310800 0x80>;
-			interrupts = <37 6>;
+			system-interrupts = <37 6>;
 			gpio-controller;
 			ngpios = <8>;
 			status = "disabled";
 			#gpio-cells = <2>;
 		};
 
-        gpio_prt17: gpio@40310880 {
+		gpio_prt17: gpio@40310880 {
 			compatible = "infineon,cat1-gpio";
 			reg = <0x40310880 0x80>;
-			interrupts = <38 6>;
+			system-interrupts = <38 6>;
 			gpio-controller;
 			ngpios = <8>;
 			status = "disabled";
 			#gpio-cells = <2>;
 		};
 
-        gpio_prt18: gpio@40310900 {
+		gpio_prt18: gpio@40310900 {
 			compatible = "infineon,cat1-gpio";
 			reg = <0x40310900 0x80>;
-			interrupts = <39 6>;
+			system-interrupts = <39 6>;
 			gpio-controller;
 			ngpios = <8>;
 			status = "disabled";
 			#gpio-cells = <2>;
 		};
 
-        gpio_prt19: gpio@40310980 {
+		gpio_prt19: gpio@40310980 {
 			compatible = "infineon,cat1-gpio";
 			reg = <0x40310980 0x80>;
-			interrupts = <40 6>;
+			system-interrupts = <40 6>;
 			gpio-controller;
 			ngpios = <8>;
 			status = "disabled";
 			#gpio-cells = <2>;
 		};
 
-        gpio_prt20: gpio@40310A00 {
+		gpio_prt20: gpio@40310A00 {
 			compatible = "infineon,cat1-gpio";
 			reg = <0x40310A00 0x80>;
-			interrupts = <41 6>;
+			system-interrupts = <41 6>;
 			gpio-controller;
 			ngpios = <8>;
 			status = "disabled";
 			#gpio-cells = <2>;
 		};
 
-        gpio_prt21: gpio@40310A80 {
+		gpio_prt21: gpio@40310A80 {
 			compatible = "infineon,cat1-gpio";
 			reg = <0x40310A80 0x80>;
-			interrupts = <42 6>;
+			system-interrupts = <42 6>;
 			gpio-controller;
 			ngpios = <8>;
 			status = "disabled";
 			#gpio-cells = <2>;
 		};
 
-        gpio_prt22: gpio@40310B00 {
+		gpio_prt22: gpio@40310B00 {
 			compatible = "infineon,cat1-gpio";
 			reg = <0x40310B00 0x80>;
-			interrupts = <43 6>;
+			system-interrupts = <43 6>;
 			gpio-controller;
 			ngpios = <8>;
 			status = "disabled";
 			#gpio-cells = <2>;
 		};
 
-        gpio_prt23: gpio@40310B80 {
+		gpio_prt23: gpio@40310B80 {
 			compatible = "infineon,cat1-gpio";
 			reg = <0x40310B80 0x80>;
-			interrupts = <44 6>;
+			system-interrupts = <44 6>;
 			gpio-controller;
 			ngpios = <8>;
 			status = "disabled";
@@ -345,7 +345,7 @@ soc {
 		};
 
 
-        scb0: scb@40600000 {
+		scb0: scb@40600000 {
 			compatible = "infineon,cat1-scb";
 			reg = <0x40600000 0x10000>;
 			#address-cells = <1>;
@@ -354,7 +354,7 @@ soc {
 			status = "disabled";
 		};
 
-        scb1: scb@40610000 {
+		scb1: scb@40610000 {
 			compatible = "infineon,scb";
 			reg = <0x40610000 0x10000>;
 			#address-cells = <1>;
@@ -418,31 +418,31 @@ soc {
 		};
 
 
-        adc0: adc@40900000 {
-	        compatible = "infineon,adc";
-            reg = <0x40900000 0x1000>;
-        	system-interrupts = <96 6>;          
-            status = "disabled";
-            #io-channel-cells = <1>;
-        };
-
-        adc1: adc@40901000 {
-	        compatible = "infineon,adc";
-	        reg = <0x40901000 0x1000>;
-	        system-interrupts = <120 6>;         
-	        status = "disabled";
-	        #io-channel-cells = <1>;
+		adc0: adc@40900000 {
+			compatible = "infineon,ifx-sar";
+			reg = <0x40900000 0x1000>;
+			system-interrupts = <96 6>;
+			status = "disabled";
+			#io-channel-cells = <1>;
 		};
 
-        adc2: adc@40902000 {
-	        compatible = "infineon,adc";
-	        reg = <0x40902000 0x1000>;
-	        system-interrupts = <152 6>;         
-	        status = "disabled";
-	        #io-channel-cells = <1>;
+		adc1: adc@40901000 {
+			compatible = "infineon,ifx-sar";
+			reg = <0x40901000 0x1000>;
+			system-interrupts = <120 6>;
+			status = "disabled";
+			#io-channel-cells = <1>;
 		};
 
-        watchdog0: watchdog@4026C000 {
+		adc2: adc@40902000 {
+			compatible = "infineon,ifx-sar";
+			reg = <0x40902000 0x1000>;
+			system-interrupts = <152 6>;
+			status = "disabled";
+			#io-channel-cells = <1>;
+		};
+
+		watchdog0: watchdog@4026C000 {
 			compatible = "infineon,cat1-watchdog";
 			reg = <0x4026C000 0x4001>;
 			system-interrupts = <15 1>;
@@ -450,14 +450,14 @@ soc {
 		};
 
 		can0_0: can@40520000 {
-            compatible = "infineon,cat1-can";
-            reg = <0x40520000 0x200>, <0x40530000 0x8000>;
-            reg-names = "m_can", "message_ram";
-            system-interrupts = <57 2>, <61 2>;
-            clocks = <&clk_hf0>;
-            bosch,mram-cfg = <0x0 28 8 3 3 1 3 3>;
-            status = "disabled";
-        };
+			compatible = "infineon,cat1-can";
+			reg = <0x40520000 0x200>, <0x40530000 0x8000>;
+			reg-names = "m_can", "message_ram";
+			system-interrupts = <57 2>, <61 2>;
+			clocks = <&clk_hf0>;
+			bosch,mram-cfg = <0x0 28 8 3 3 1 3 3>;
+			status = "disabled";
+		};
 
 
 		dma0: dw@40280000 {
@@ -466,94 +466,94 @@ soc {
 			reg = <0x40280000 0x10000>;
 			dma-channels = <89>;
 			system-interrupts = <164 6>, /* CH0 */
-					    		<165 6>, /* CH1 */
-					    		<166 6>, /* CH2 */
-					    		<167 6>, /* CH3 */
-					    		<168 6>, /* CH4 */
-					    		<169 6>, /* CH5 */
-					    		<170 6>, /* CH6 */
-					    		<171 6>, /* CH7 */
-					   			<172 6>, /* CH8 */
-					    		<173 6>, /* CH9 */
-					    		<174 6>, /* CH10 */
-					    		<175 6>, /* CH11 */
-					    		<176 6>, /* CH12 */
-					    		<177 6>, /* CH13 */
-					    		<178 6>, /* CH14 */
-					    		<179 6>, /* CH15 */
-					    		<180 6>, /* CH16 */
-					    		<181 6>, /* CH17 */
-					    		<182 6>, /* CH18 */
-					    		<183 6>, /* CH19 */
-					    		<184 6>, /* CH20 */
-					    		<185 6>, /* CH21 */
-					    		<186 6>, /* CH22 */
-					    		<187 6>, /* CH23 */
-					    		<188 6>, /* CH24 */
-					    		<189 6>, /* CH25 */
-					    		<190 6>, /* CH26 */
-					    		<191 6>, /* CH27 */
-					    		<192 6>, /* CH28 */
-					    		<193 6>, /* CH29 */
-					    		<194 6>, /* CH30 */
-					    		<195 6>, /* CH31 */
-					    		<196 6>, /* CH32 */
-					    		<197 6>, /* CH33 */
-					    		<198 6>, /* CH34 */
-					    		<199 6>, /* CH35 */
-					    		<200 6>, /* CH36 */
-					    		<201 6>, /* CH37 */
-					    		<202 6>, /* CH38 */
-					    		<203 6>, /* CH39 */
-					    		<204 6>, /* CH40 */
-					    		<205 6>, /* CH41 */
-					    		<206 6>, /* CH42 */
-					    		<207 6>, /* CH43 */
-					    		<208 6>, /* CH44 */
-					    		<209 6>, /* CH45 */
-					    		<210 6>, /* CH46 */
-					    		<211 6>, /* CH47 */
-					    		<212 6>, /* CH48 */
-					    		<213 6>, /* CH49 */
-					    		<214 6>, /* CH50 */
-					    		<215 6>, /* CH51 */
-					    		<216 6>, /* CH52 */
-					    		<217 6>, /* CH53 */
-					    		<218 6>, /* CH54 */
-					    		<219 6>, /* CH55 */
-					    		<220 6>, /* CH56 */
-					    		<221 6>, /* CH57 */
-					    		<222 6>, /* CH58 */
-					    		<223 6>, /* CH59 */
-					    		<224 6>, /* CH60 */
-					    		<225 6>, /* CH61 */
-					    		<226 6>, /* CH62 */
-					    		<227 6>, /* CH63 */
-					    		<228 6>, /* CH64 */
-					    		<229 6>, /* CH65 */
-					    		<230 6>, /* CH66 */
-					    		<231 6>, /* CH67 */
-					    		<232 6>, /* CH68 */
-					    		<233 6>, /* CH69 */
-					    		<234 6>, /* CH70 */
-					    		<235 6>, /* CH71 */
-					    		<236 6>, /* CH72 */
-					    		<237 6>, /* CH73 */
-					    		<238 6>, /* CH74 */
-					    		<239 6>, /* CH75 */
-					    		<240 6>, /* CH76 */
-					   		 	<241 6>, /* CH77 */
-					    		<242 6>, /* CH78 */
-					    		<243 6>, /* CH79 */
-					    		<244 6>, /* CH80 */
-					    		<245 6>, /* CH81 */
-					    		<246 6>, /* CH82 */
-					    		<247 6>, /* CH83 */
-					    		<248 6>, /* CH84 */
-					    		<249 6>, /* CH85 */
-					    		<250 6>, /* CH86 */
-					    		<251 6>, /* CH87 */
-					    		<252 6>, /* CH88 */
+								<165 6>, /* CH1 */
+								<166 6>, /* CH2 */
+								<167 6>, /* CH3 */
+								<168 6>, /* CH4 */
+								<169 6>, /* CH5 */
+								<170 6>, /* CH6 */
+								<171 6>, /* CH7 */
+								<172 6>, /* CH8 */
+								<173 6>, /* CH9 */
+								<174 6>, /* CH10 */
+								<175 6>, /* CH11 */
+								<176 6>, /* CH12 */
+								<177 6>, /* CH13 */
+								<178 6>, /* CH14 */
+								<179 6>, /* CH15 */
+								<180 6>, /* CH16 */
+								<181 6>, /* CH17 */
+								<182 6>, /* CH18 */
+								<183 6>, /* CH19 */
+								<184 6>, /* CH20 */
+								<185 6>, /* CH21 */
+								<186 6>, /* CH22 */
+								<187 6>, /* CH23 */
+								<188 6>, /* CH24 */
+								<189 6>, /* CH25 */
+								<190 6>, /* CH26 */
+								<191 6>, /* CH27 */
+								<192 6>, /* CH28 */
+								<193 6>, /* CH29 */
+								<194 6>, /* CH30 */
+								<195 6>, /* CH31 */
+								<196 6>, /* CH32 */
+								<197 6>, /* CH33 */
+								<198 6>, /* CH34 */
+								<199 6>, /* CH35 */
+								<200 6>, /* CH36 */
+								<201 6>, /* CH37 */
+								<202 6>, /* CH38 */
+								<203 6>, /* CH39 */
+								<204 6>, /* CH40 */
+								<205 6>, /* CH41 */
+								<206 6>, /* CH42 */
+								<207 6>, /* CH43 */
+								<208 6>, /* CH44 */
+								<209 6>, /* CH45 */
+								<210 6>, /* CH46 */
+								<211 6>, /* CH47 */
+								<212 6>, /* CH48 */
+								<213 6>, /* CH49 */
+								<214 6>, /* CH50 */
+								<215 6>, /* CH51 */
+								<216 6>, /* CH52 */
+								<217 6>, /* CH53 */
+								<218 6>, /* CH54 */
+								<219 6>, /* CH55 */
+								<220 6>, /* CH56 */
+								<221 6>, /* CH57 */
+								<222 6>, /* CH58 */
+								<223 6>, /* CH59 */
+								<224 6>, /* CH60 */
+								<225 6>, /* CH61 */
+								<226 6>, /* CH62 */
+								<227 6>, /* CH63 */
+								<228 6>, /* CH64 */
+								<229 6>, /* CH65 */
+								<230 6>, /* CH66 */
+								<231 6>, /* CH67 */
+								<232 6>, /* CH68 */
+								<233 6>, /* CH69 */
+								<234 6>, /* CH70 */
+								<235 6>, /* CH71 */
+								<236 6>, /* CH72 */
+								<237 6>, /* CH73 */
+								<238 6>, /* CH74 */
+								<239 6>, /* CH75 */
+								<240 6>, /* CH76 */
+								<241 6>, /* CH77 */
+								<242 6>, /* CH78 */
+								<243 6>, /* CH79 */
+								<244 6>, /* CH80 */
+								<245 6>, /* CH81 */
+								<246 6>, /* CH82 */
+								<247 6>, /* CH83 */
+								<248 6>, /* CH84 */
+								<249 6>, /* CH85 */
+								<250 6>, /* CH86 */
+								<251 6>, /* CH87 */
+								<252 6>, /* CH88 */
 								<253 6>, /* CH89 */
 								<254 6>, /* CH90 */
 								<255 6>; /* CH91 */
@@ -568,38 +568,38 @@ soc {
 			reg = <0x40290000 0x10000>;
 			dma-channels = <33>;
 			system-interrupts = <241 6>, /* CH0 */
-					    <256 6>, /* CH1 */
-					    <257 6>, /* CH2 */
-					    <258 6>, /* CH3 */
-					    <259 6>, /* CH4 */
-					    <260 6>, /* CH5 */
-					    <261 6>, /* CH6 */
-					    <262 6>, /* CH7 */
-					    <263 6>, /* CH8 */
-					    <264 6>, /* CH9 */
-					    <265 6>, /* CH10 */
-					    <266 6>, /* CH11 */
-					    <267 6>, /* CH12 */
-					    <268 6>, /* CH13 */
-					    <269 6>, /* CH14 */
-					    <270 6>, /* CH15 */
-					    <271 6>, /* CH16 */
-					    <272 6>, /* CH17 */
-					    <273 6>, /* CH18 */
-					    <274 6>, /* CH19 */
-					    <275 6>, /* CH20 */
-					    <276 6>, /* CH21 */
-					    <277 6>, /* CH22 */
-					    <278 6>, /* CH23 */
-					    <279 6>, /* CH24 */
-					    <280 6>, /* CH25 */
-					    <281 6>, /* CH26 */
-					    <282 6>, /* CH27 */
-					    <283 6>, /* CH28 */
-					    <284 6>, /* CH29 */
-					    <285 6>, /* CH30 */
-					    <286 6>, /* CH31 */
-					    <287 6>, /* CH32 */
+						<256 6>, /* CH1 */
+						<257 6>, /* CH2 */
+						<258 6>, /* CH3 */
+						<259 6>, /* CH4 */
+						<260 6>, /* CH5 */
+						<261 6>, /* CH6 */
+						<262 6>, /* CH7 */
+						<263 6>, /* CH8 */
+						<264 6>, /* CH9 */
+						<265 6>, /* CH10 */
+						<266 6>, /* CH11 */
+						<267 6>, /* CH12 */
+						<268 6>, /* CH13 */
+						<269 6>, /* CH14 */
+						<270 6>, /* CH15 */
+						<271 6>, /* CH16 */
+						<272 6>, /* CH17 */
+						<273 6>, /* CH18 */
+						<274 6>, /* CH19 */
+						<275 6>, /* CH20 */
+						<276 6>, /* CH21 */
+						<277 6>, /* CH22 */
+						<278 6>, /* CH23 */
+						<279 6>, /* CH24 */
+						<280 6>, /* CH25 */
+						<281 6>, /* CH26 */
+						<282 6>, /* CH27 */
+						<283 6>, /* CH28 */
+						<284 6>, /* CH29 */
+						<285 6>, /* CH30 */
+						<286 6>, /* CH31 */
+						<287 6>, /* CH32 */
 						<288 6>, /* CH33 */
 						<289 6>, /* CH34 */
 						<290 6>, /* CH35 */
@@ -618,6 +618,6 @@ soc {
 
 
 
-       
+
+		};
 	};
-};

--- a/dts/arm/infineon/cat1a/cyt2bl/system_clocks.dtsi
+++ b/dts/arm/infineon/cat1a/cyt2bl/system_clocks.dtsi
@@ -4,143 +4,143 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#define DIV_8_BIT    00
-#define DIV_16_BIT    01
-#define DIV_16_5_BIT    02
-#define DIV_24_5_BIT    03
+#define DIV_8_BIT	 00
+#define DIV_16_BIT	  01
+#define DIV_16_5_BIT	02
+#define DIV_24_5_BIT	03
 
 #include <dt-bindings/clock/ifx_clock_source_def.h>
  / {
-    clocks {
-        clk_wco: clk_wco{
-            #clock-cells = <0>;
-            compatible = "fixed-clock";
-            status = "disabled";
-        };
+	clocks {
+		clk_wco: clk_wco{
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			status = "disabled";
+		};
 
-        clk_ilo0: clk_ilo0 {
-            #clock-cells = <0>;
-            compatible = "fixed-clock";
-            clock-frequency = <32768>;
-            status = "disabled";
-        };
+		clk_ilo0: clk_ilo0 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <32768>;
+			status = "disabled";
+		};
 
-        clk_ilo1: clk_ilo1 {
-            #clock-cells = <0>;
-            compatible = "fixed-clock";
-            clock-frequency = <32768>;
-            status = "disabled";
-        };
+		clk_ilo1: clk_ilo1 {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <32768>;
+			status = "disabled";
+		};
 
-        path-source {
-            #address-cells = <1>;
-            #size-cells = <0>;
+		path-source {
+			#address-cells = <1>;
+			#size-cells = <0>;
 
-            /* imo */
-            clk_imo: clk_imo@0 {
-                #clock-cells = <0>;
-                compatible = "fixed-clock";
-                reg = <0>;
-                clock-frequency = <8000000>;
-                status = "okay";
-            };
+			/* imo */
+			clk_imo: clk_imo@0 {
+				#clock-cells = <0>;
+				compatible = "fixed-clock";
+				reg = <0>;
+				clock-frequency = <8000000>;
+				status = "okay";
+			};
 
-            clk_ext: clk_ext@1 {
-                #clock-cells = <0>;
-                compatible = "fixed-clock";
-                reg = <1>;
-                status = "disabled";
-            };
+			clk_ext: clk_ext@1 {
+				#clock-cells = <0>;
+				compatible = "fixed-clock";
+				reg = <1>;
+				status = "disabled";
+			};
 
-            clk_eco: clk_eco@2 {
-                #clock-cells = <0>;
-                compatible = "fixed-clock";
-                reg = <2>;
-                status = "disabled";
-            };
+			clk_eco: clk_eco@2 {
+				#clock-cells = <0>;
+				compatible = "fixed-clock";
+				reg = <2>;
+				status = "disabled";
+			};
 
-            clk_althf: clk_althf@3 {
-                #clock-cells = <0>;
-                compatible = "fixed-clock";
-                reg = <3>;
-                status = "disabled";
-            };
-        };
+			clk_althf: clk_althf@3 {
+				#clock-cells = <0>;
+				compatible = "fixed-clock";
+				reg = <3>;
+				status = "disabled";
+			};
+		};
 
-        direct {
-            #address-cells = <1>;
-            #size-cells = <0>;
-            clk_direct0: clk_direct@5 {
-                #clock-cells = <0>;
-                compatible = "fixed-clock";
-                reg = <5>;
-                clocks = <&clk_eco>;
-                status = "disabled";
-            };
-        };
+		direct {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clk_direct0: clk_direct@5 {
+				#clock-cells = <0>;
+				compatible = "fixed-clock";
+				reg = <5>;
+				clocks = <&clk_eco>;
+				status = "disabled";
+			};
+		};
 
 
-        fll {
-            #address-cells = <1>;
-            #size-cells = <0>;
+		fll {
+			#address-cells = <1>;
+			#size-cells = <0>;
 
-            /* fll */
-            fll: fll@0 {
-                #clock-cells = <0>;
-                reg = <0>;
-                compatible = "fixed-clock";
-                clock-frequency = <80000000>;
-                status = "disabled";
-            };
-        };
+			/* fll */
+			fll: fll@0 {
+				#clock-cells = <0>;
+				reg = <0>;
+				compatible = "fixed-clock";
+				clock-frequency = <80000000>;
+				status = "disabled";
+			};
+		};
 
-        pll {
-            #address-cells = <1>;
-            #size-cells = <0>;
+		pll {
+			#address-cells = <1>;
+			#size-cells = <0>;
 
-            pll0: pll@1 {
-                #clock-cells = <0>;
-                compatible = "infineon,cat1-pll";
-                reg = <1>;
-                clocks = <&clk_imo>;
-                p-div = <25>;
-                q-div = <2>;
-                frac-div = <0x00000>;
-                output-div = <2>;
-                status = "okay";
-            };
-        };
+			pll0: pll@1 {
+				#clock-cells = <0>;
+				compatible = "infineon,cat1-pll";
+				reg = <1>;
+				clocks = <&clk_eco>;
+				p-div = <25>;
+				q-div = <2>;
+				frac-div = <0x00000>;
+				output-div = <2>;
+				status = "disabled";
+			};
+		};
 
-        clk_hf {
-            #address-cells = <1>;
-            #size-cells = <0>;
+		clk_hf {
+			#address-cells = <1>;
+			#size-cells = <0>;
 
-            clk_hf0: clk_hf@0 {
-                #clock-cells = <0>;
-                compatible = "infineon,cat1-hf-clock";
-                reg = <0>;
-                clocks = <&pll0>;
-                divider = <2>;
-                status = "okay";
-            };
+			clk_hf0: clk_hf@0 {
+				#clock-cells = <0>;
+				compatible = "infineon,cat1-hf-clock";
+				reg = <0>;
+				clocks = <&pll0>;
+				divider = <1>;
+				status = "okay";
+			};
 
-            clk_hf1: clk_hf@1 {
-                #clock-cells = <0>;
-                compatible = "infineon,cat1-hf-clock";
-                reg = <1>;
-                clocks = <&pll0>;
-                divider = <1>;
-                status = "disabled";
-            };
+			clk_hf1: clk_hf@1 {
+				#clock-cells = <0>;
+				compatible = "infineon,cat1-hf-clock";
+				reg = <1>;
+				clocks = <&pll0>;
+				divider = <1>;
+				status = "disabled";
+			};
 
-            clk_hf2: clk_hf@2 {
-                #clock-cells = <0>;
-                compatible = "infineon,cat1-hf-clock";
-                reg = <2>;
-                clocks = <&pll0>;
-                divider = <2>;
-                status = "disabled";
-            };
-        };
-    };
+			clk_hf2: clk_hf@2 {
+				#clock-cells = <0>;
+				compatible = "infineon,cat1-hf-clock";
+				reg = <2>;
+				clocks = <&pll0>;
+				divider = <2>;
+				status = "disabled";
+			};
+		};
+	};
 };

--- a/samples/drivers/adc/adc_dt/boards/kit_t2g_b_e_lite.overlay
+++ b/samples/drivers/adc/adc_dt/boards/kit_t2g_b_e_lite.overlay
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025 Linumiz GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/pinctrl/ifx_cat1-pinctrl.h>
+#include <zephyr/dt-bindings/adc/adc.h>
+
+/ {
+	zephyr,user {
+		io-channels = <&adc0 0>;
+	};
+};
+
+&pinctrl {
+	/* Configure P6.0 for analog input */
+	p6_0_pass0_sar0_an14: p6_6_pass0_sar0_an14 {
+		pinmux = <DT_CAT1_PINMUX(6, 0, HSIOM_SEL_AMUXA)>;
+	};
+};
+
+&adc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	pinctrl-0 = <&p6_0_pass0_sar0_an14>;
+	pinctrl-names = "default";
+
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,vref-mv = <3300>;  /* VDDA = 3.3V reference */
+
+		zephyr,input-positive = <0>;
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_MICROSECONDS, 1)>;
+	};
+};

--- a/soc/infineon/cat1a/cyt2bl/soc.c
+++ b/soc/infineon/cat1a/cyt2bl/soc.c
@@ -6,7 +6,7 @@
  */
 
 /**
- * @brief Infineon PSOC 6 SOC.
+ * @brief Infineon CYT2BL SOC.
  */
 
 #include <zephyr/device.h>
@@ -44,7 +44,10 @@ void enable_sys_int(uint32_t int_num, uint32_t priority, void (*isr)(const void 
 		sys_int_table[int_num].isr = isr;
 	} else {
 		k_fatal_halt(K_ERR_CPU_EXCEPTION);
+
 	}
+	 NVIC_ClearPendingIRQ(int_num);
+     NVIC_EnableIRQ(priority);
 }
 
 void sys_int_handler(uint32_t intrNum)


### PR DESCRIPTION
**Description:**
To enable and update peripheral support for CYT2BL SoC, primarily targeting kit_t2g_b_e_lite.

**Clock Updates**
        •	Switched PLL source from IMO to ECO for improved stability
	•	Updated PLL and HF clock divider values
	•	Adjusted peripheral clock (peri) assignments and dividers
	•	Updated system_clocks.dtsi accordingly
	
**Devicetree Updates**
        •	Added/updated peripheral nodes in cyt2bl.dtsi and package DTSI
	•	Updated system interrupt configuration for enabled IP blocks
	•	Ensured proper clock and interrupt mapping for peripherals
	
**SoC Updates**
	•	Minor updates in soc.c to align interrupt initialization 

**Sample Support**
	•	Added kit_t2g_b_e_lite overlay for adc_dt sample
	
**Testing and Validation:**
These changes allow stable bring-up and validation of:
        •	Blinky
        •	UART Console
        •	GPIO interrupts (button press)
        •	Watchdog
	•	ADC
	•	I2C
	•	SPI
	•	CAN
     
      
       
     
 

