### PR TITLE
Infineon: cyt4bf/cytvii_b_h_8m_320_cpu : SoC and Board Support

### DIFF
--- a/boards/infineon/cytvii-b-h-8m-320-cpu/cytvii_b_h_8m_320_cpu_common.dtsi
+++ b/boards/infineon/cytvii-b-h-8m-320-cpu/cytvii_b_h_8m_320_cpu_common.dtsi
@@ -237,7 +237,7 @@ uart3: &scb3 {
 	pinctrl-names = "default";
 };
 
-&adc0 {
+&adc1 {
 	status = "okay";
 	clocks = <&clk_hf2>;
 
@@ -429,7 +429,7 @@ can0: &can0_0 {
 	status = "okay";
 };
 
-&adc0 {
+&adc1 {
 	status = "okay";
 };
 

--- a/boards/infineon/cytvii-b-h-8m-320-cpu/cytvii_b_h_8m_320_cpu_common.dtsi
+++ b/boards/infineon/cytvii-b-h-8m-320-cpu/cytvii_b_h_8m_320_cpu_common.dtsi
@@ -10,6 +10,7 @@
 #include <zephyr/dt-bindings/pinctrl/ifx_cat1-pinctrl.h>
 #include <dt-bindings/adc/adc.h>
 #include <common/freq.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 / {
 	aliases {
@@ -37,6 +38,7 @@
 		dma0 = &dma0;
 		uart3 = &uart3;
 		eeprom-0 = &eeprom0;
+		pwm-led0 = &pwm_led0;
 	};
 
 	leds {
@@ -140,6 +142,14 @@
 			label = "SW_5";
 			gpios = <&gpio_prt28 1 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			zephyr,code = <INPUT_KEY_5>;
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		pwm_led0: pwm_led_0 {
+			pwms = <&tcpwm1_grp0_pwm 18 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
 

--- a/boards/infineon/cytvii-b-h-8m-320-cpu/cytvii_b_h_8m_320_cpu_cyt4bfcche_m7_0.dts
+++ b/boards/infineon/cytvii-b-h-8m-320-cpu/cytvii_b_h_8m_320_cpu_cyt4bfcche_m7_0.dts
@@ -18,7 +18,7 @@
 	compatible = "infineon,cytvii-b-h-8m-320-cpu", "infineon,CYTVIIBH8M";
 
 	aliases {
-		adc0 = &adc0;
+		adc1 = &adc1;
 	};
 
 	chosen {

--- a/drivers/spi/spi_ifx_cat1_pdl.c
+++ b/drivers/spi/spi_ifx_cat1_pdl.c
@@ -567,8 +567,15 @@ static int ifx_cat1_spi_init(const struct device *dev)
 		(NULL))},
 
 #if defined(CONFIG_SOC_FAMILY_INFINEON_CAT1C)
-#define SPI_DMA_TRIGGERS(index)                                                                    \
+
+#if defined(CONFIG_SOC_SERIES_CYT4DN)  
+#define SPI_DMA_TRIGGERS(index)                                                                  \
 	.spi_rx_trigger	= TRIG_OUT_1TO1_1_SCB_RX_TO_PDMA10,
+#else
+#define SPI_DMA_TRIGGERS(index)                                                                  \
+	.spi_rx_trigger	= TRIG_OUT_1TO1_2_SCB_RX_TO_PDMA10,
+#endif
+
 #else
 #define SPI_DMA_TRIGGERS(index)                                                                    \
 	.spi_rx_trigger = (en_peri0_trig_input_pdma0_tr_t)(PERI_0_TRIG_IN_MUX_0_SCB_RX_TR_OUT0),   \

--- a/dts/arm/infineon/cat1c/traveo2-8m/cyt4bf.dtsi
+++ b/dts/arm/infineon/cat1c/traveo2-8m/cyt4bf.dtsi
@@ -2187,10 +2187,10 @@
 
 		dma0: dw@40280000 {
 			#dma-cells = <1>;
-			compatible = "infineon,cat1-dma";
+			compatible = "infineon,cat1-dma-pdl";
 			reg = <0x40280000 0x10000>;
 			dma-channels = <143>;
-			system-interrupts = <227 6>, /* CH0 */
+			interrupts = <227 6>, /* CH0 */
 								<228 6>, /* CH1 */
 								<229 6>, /* CH2 */
 								<230 6>, /* CH3 */
@@ -2337,10 +2337,10 @@
 		};
 		dma1: dw@40290000 {
 			#dma-cells = <1>;
-			compatible = "infineon,cat1-dma";
+			compatible = "infineon,cat1-dma-pdl";
 			reg = <0x40290000 0x10000>;
 			dma-channels = <65>;
-			system-interrupts = <370 6>, /* CH0 */
+			interrupts = <370 6>, /* CH0 */
 								<371 6>, /* CH1 */
 								<372 6>, /* CH2 */
 								<373 6>, /* CH3 */

--- a/dts/arm/infineon/cat1c/traveo2-8m/cyt4bf.dtsi
+++ b/dts/arm/infineon/cat1c/traveo2-8m/cyt4bf.dtsi
@@ -526,1661 +526,2338 @@
 			status = "disabled";
 		};
 
-		tcpwm0_grp0: tcpwm0@40380000 {
-			reg = <0x40380000 0x80>;
+			tcpwm0: tcpwm0@40380000 {
+			reg = <0x40380000 0x2900>;
 			#address-cells = <1>;
 			#size-cells = <1>;
-
-			tcpwm0_0: tcpwm0_0@40380000 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380000 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_0: counter0_0 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <552 4>;
+			tcpwm0_grp0: tcpwm@40380000 {
+				reg = <0x40380000 0x180>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+				tcpwm0_grp0_pwm: pwm@40380000 {
+					compatible = "infineon,cat1-pwm";
+					reg = <0x40380000 0x180>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+					#pwm-cells = <3>;
+					resolution = <16>;
 					status = "disabled";
+
+					pwm_ch0_0: channel@0 {
+						reg = <0x0>;
+						system-interrupts = <519 4>;
+						status = "disabled";
+					};
+
+					pwm_ch0_1: channel@1 {
+						reg = <0x1>;
+						system-interrupts = <520 4>;
+						status = "disabled";
+					};
+
+					pwm_ch0_2: channel@2 {
+						reg = <0x2>;
+						system-interrupts = <521 4>;
+						status = "disabled";
+					};
 				};
 
-				pwm0_0: pwm0_0 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <552 4>;
-					#pwm-cells = <3>;
+				tcpwm0_grp0_tgpio: tgpio@40380000 {
+					compatible = "infineon,tcpwm-tgpio";
+					reg = <0x40380000 0x180>;
+					#address-cells = <1>;
+					#size-cells = <0>;
 					status = "disabled";
+
+					tgpio_ch0_0: channel@0 {
+						reg = <0x0>;
+						system-interrupts = <519 4>;
+						status = "disabled";
+					};
+
+					tgpio_ch0_1: channel@1 {
+						reg = <0x1>;
+						system-interrupts = <520 4>;
+						status = "disabled";
+					};
+
+					tgpio_ch0_2: channel@2 {
+						reg = <0x2>;
+						system-interrupts = <521 4>;
+						status = "disabled";
+					};
+				};
+				tcpwm0_grp0_cnt: tcpwm@40380000 {
+					compatible = "infineon,tcpwm";
+					reg = <0x40380000 0x180>;
+					#address-cells = <1>;
+					#size-cells = <1>;
+					resolution = <16>;
+					status = "disabled";
+
+					counter0_0: counter@40380000 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40380000 0x80>;
+						system-interrupts = <519 4>;
+						status = "disabled";
+					};
+
+					counter0_1: counter@40380080 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40380080 0x80>;
+						system-interrupts = <520 4>;
+						status = "disabled";
+					};
+
+					counter0_2: counter@40380100 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40380100 0x80>;
+						system-interrupts = <521 4>;
+						status = "disabled";
+					};
+				};
+			};
+			tcpwm0_grp1: tcpwm@40388000 {
+				reg = <0x40388000 0x180>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+				tcpwm0_grp1_pwm: pwm@40388000 {
+					compatible = "infineon,cat1-pwm";
+					reg = <0x40388000 0x180>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+					#pwm-cells = <3>;
+					resolution = <16>;
+					status = "disabled";
+
+					pwm_ch1_0: channel@0 {
+						reg = <0x0>;
+						system-interrupts = <534 4>;
+						status = "disabled";
+					};
+
+					pwm_ch1_1: channel@1 {
+						reg = <0x1>;
+						system-interrupts = <535 4>;
+						status = "disabled";
+					};
+
+					pwm_ch1_2: channel@2 {
+						reg = <0x2>;
+						system-interrupts = <536 4>;
+						status = "disabled";
+					};
+				};
+
+			tcpwm0_grp1_cnt: tcpwm@40388000 {
+					compatible = "infineon,tcpwm";
+					reg = <0x40388000 0x180>;
+					#address-cells = <1>;
+					#size-cells = <1>;
+					resolution = <16>;
+					status = "disabled";
+
+					counter1_0: counter@40388000 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40388000 0x80>;
+						system-interrupts = <534 4>;
+						status = "disabled";
+					};
+
+					counter1_1: counter@40388080 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40388080 0x80>;
+						system-interrupts = <535 4>;
+						status = "disabled";
+					};
+
+					counter1_2: counter@40388100 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40388100 0x80>;
+						system-interrupts = <536 4>;
+						status = "disabled";
+					};
 				};
 			};
 
-			tcpwm0_1: tcpwm0_1@40380080 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380080 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_1: counter0_1 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <553 4>;
-					status = "disabled";
-				};
-
-				pwm0_1: pwm0_1 {
+			tcpwm0_grp2: tcpwm@40390000 {
+				reg = <0x40390000 0x180>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+				tcpwm0_grp2_pwm: pwm@40390000 {
 					compatible = "infineon,cat1-pwm";
-					system-interrupts = <553 4>;
+					reg = <0x40390000 0x180>;
+					#address-cells = <1>;
+					#size-cells = <0>;
 					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_2: tcpwm0_2@40380100 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380100 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_2: counter0_2 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <554 4>;
-					status = "disabled";
-				};
-
-				pwm0_2: pwm0_2 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <554 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_3: tcpwm0_3@40380180 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380180 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_3: counter0_3 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <555 4>;
-					status = "disabled";
-				};
-
-				pwm0_3: pwm0_3 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <555 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_4: tcpwm0_4@40380200 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380200 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_4: counter0_4 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <556 4>;
-					status = "disabled";
-				};
-
-				pwm0_4: pwm0_4 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <556 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_5: tcpwm0_5@40380280 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380280 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_5: counter0_5 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <557 4>;
-					status = "disabled";
-				};
-
-				pwm0_5: pwm0_5 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <557 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_6: tcpwm0_6@40380300 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380300 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_6: counter0_6 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <558 4>;
-					status = "disabled";
-				};
-
-				pwm0_6: pwm0_6 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <558 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_7: tcpwm0_7@40380380 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380380 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_7: counter0_7 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <559 4>;
-					status = "disabled";
-				};
-
-				pwm0_7: pwm0_7 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <559 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_8: tcpwm0_8@40380400 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380400 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_8: counter0_8 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <560 4>;
-					status = "disabled";
-				};
-
-				pwm0_8: pwm0_8 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <560 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_9: tcpwm0_9@40380480 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380480 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_9: counter0_9 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <561 4>;
-					status = "disabled";
-				};
-
-				pwm0_9: pwm0_9 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <561 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_10: tcpwm0_10@40380500 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380500 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_10: counter0_10 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <562 4>;
-					status = "disabled";
-				};
-
-				pwm0_10: pwm0_10 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <562 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_11: tcpwm0_11@40380580 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380580 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_11: counter0_11 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <563 4>;
-					status = "disabled";
-				};
-
-				pwm0_11: pwm0_11 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <563 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_12: tcpwm0_12@40380600 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380600 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_12: counter0_12 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <564 4>;
-					status = "disabled";
-				};
-
-				pwm0_12: pwm0_12 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <564 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_13: tcpwm0_13@40380680 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380680 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_13: counter0_13 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <565 4>;
-					status = "disabled";
-				};
-
-				pwm0_13: pwm0_13 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <565 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_14: tcpwm0_14@40380700 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380700 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_14: counter0_14 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <566 4>;
-					status = "disabled";
-				};
-
-				pwm0_14: pwm0_14 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <566 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_15: tcpwm0_15@40380780 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380780 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_15: counter0_15 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <567 4>;
-					status = "disabled";
-				};
-
-				pwm0_15: pwm0_15 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <567 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_16: tcpwm0_16@40380800 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380800 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_16: counter0_16 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <568 4>;
-					status = "disabled";
-				};
-
-				pwm0_16: pwm0_16 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <568 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_17: tcpwm0_17@40380880 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380880 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_17: counter0_17 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <569 4>;
-					status = "disabled";
-				};
-
-				pwm0_17: pwm0_17 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <569 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_18: tcpwm0_18@40380900 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380900 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_18: counter0_18 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <570 4>;
-					status = "disabled";
-				};
-
-				pwm0_18: pwm0_18 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <570 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_19: tcpwm0_19@40380980 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380980 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_19: counter0_19 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <571 4>;
-					status = "disabled";
-				};
-
-				pwm0_19: pwm0_19 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <571 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_20: tcpwm0_20@40380A00 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380A00 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_20: counter0_20 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <572 4>;
-					status = "disabled";
-				};
-
-				pwm0_20: pwm0_20 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <572 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_21: tcpwm0_21@40380A80 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380A80 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_21: counter0_21 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <573 4>;
-					status = "disabled";
-				};
-
-				pwm0_21: pwm0_21 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <573 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_22: tcpwm0_22@40380B00 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380B00 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_22: counter0_22 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <574 4>;
-					status = "disabled";
-				};
-
-				pwm0_22: pwm0_22 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <574 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_23: tcpwm0_23@40380B80 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380B80 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_23: counter0_23 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <575 4>;
-					status = "disabled";
-				};
-
-				pwm0_23: pwm0_23 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <575 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_24: tcpwm0_24@40380C00 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380C00 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_24: counter0_24 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <576 4>;
-					status = "disabled";
-				};
-
-				pwm0_24: pwm0_24 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <576 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_25: tcpwm0_25@40380C80 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380C80 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_25: counter0_25 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <577 4>;
-					status = "disabled";
-				};
-
-				pwm0_25: pwm0_25 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <577 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_26: tcpwm0_26@40380D00 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380D00 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_26: counter0_26 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <578 4>;
-					status = "disabled";
-				};
-
-				pwm0_26: pwm0_26 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <578 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_27: tcpwm0_27@40380D80 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380D80 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_27: counter0_27 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <579 4>;
-					status = "disabled";
-				};
-
-				pwm0_27: pwm0_27 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <579 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_28: tcpwm0_28@40380E00 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380E00 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_28: counter0_28 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <580 4>;
-					status = "disabled";
-				};
-
-				pwm0_28: pwm0_28 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <580 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_29: tcpwm0_29@40380E80 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380E80 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_29: counter0_29 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <581 4>;
-					status = "disabled";
-				};
-
-				pwm0_29: pwm0_29 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <581 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_30: tcpwm0_30@40380F00 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380F00 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_30: counter0_30 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <582 4>;
-					status = "disabled";
-				};
-
-				pwm0_30: pwm0_30 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <582 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_31: tcpwm0_31@40380F80 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40380F80 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_31: counter0_31 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <583 4>;
-					status = "disabled";
-				};
-
-				pwm0_31: pwm0_31 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <583 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_32: tcpwm0_32@40381000 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40381000 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_32: counter0_32 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <584 4>;
-					status = "disabled";
-				};
-
-				pwm0_32: pwm0_32 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <584 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_33: tcpwm0_33@40381080 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40381080 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_33: counter0_33 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <585 4>;
-					status = "disabled";
-				};
-
-				pwm0_33: pwm0_33 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <585 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_34: tcpwm0_34@40381100 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40381100 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_34: counter0_34 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <586 4>;
-					status = "disabled";
-				};
-
-				pwm0_34: pwm0_34 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <586 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_35: tcpwm0_35@40381180 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40381180 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_35: counter0_35 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <587 4>;
-					status = "disabled";
-				};
-
-				pwm0_35: pwm0_35 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <587 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_36: tcpwm0_36@40381200 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40381200 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_36: counter0_36 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <588 4>;
-					status = "disabled";
-				};
-
-				pwm0_36: pwm0_36 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <588 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm0_37: tcpwm0_37@40381280 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40381280 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter0_37: counter0_37 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <589 4>;
-					status = "disabled";
-				};
-
-				pwm0_37: pwm0_37 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <589 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
+					resolution = <32>;
+					status = "disabled";
+
+					pwm_ch2_0: channel@0 {
+						reg = <0x0>;
+						system-interrupts = <550 4>;
+						status = "disabled";
+					};
+
+					pwm_ch2_1: channel@1 {
+						reg = <0x1>;
+						system-interrupts = <551 4>;
+						status = "disabled";
+					};
+
+					pwm_ch2_2: channel@2 {
+						reg = <0x2>;
+						system-interrupts = <552 4>;
+						status = "disabled";
+					};
+				};
+
+				tcpwm0_grp2_tgpio: tgpio@40390000 {
+					compatible = "infineon,tcpwm-tgpio";
+					reg = <0x40390000 0x180>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+					status = "disabled";
+
+					tgpio_ch2_0: channel@0 {
+						reg = <0x0>;
+						system-interrupts = <550 4>;
+						status = "disabled";
+					};
+
+					tgpio_ch2_1: channel@1 {
+						reg = <0x1>;
+						system-interrupts = <551 4>;
+						status = "disabled";
+					};
+
+					tgpio_ch2_2: channel@2 {
+						reg = <0x2>;
+						system-interrupts = <552 4>;
+						status = "disabled";
+					};
+				};
+			tcpwm0_grp2_cnt: tcpwm@40390000 {
+					compatible = "infineon,tcpwm";
+					reg = <0x40390000 0x180>;
+					#address-cells = <1>;
+					#size-cells = <1>;
+					resolution = <32>;
+					status = "disabled";
+
+					counter2_0: counter@40390000 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40390000 0x80>;
+						system-interrupts = <550 4>;
+						status = "disabled";
+					};
+
+					counter2_1: counter@40390080 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40390080 0x80>;
+						system-interrupts = <551 4>;
+						status = "disabled";
+					};
+
+					counter2_2: counter@40390100 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40390100 0x80>;
+						system-interrupts = <552 4>;
+						status = "disabled";
+					};
 				};
 			};
 		};
 
-		tcpwm0_grp1: tcpwm0@40388000 {
-			reg = <0x40388000 0x80>;
+
+		tcpwm1: tcpwm1@40580000 {
+			reg = <0x40580000 0x3080>;
 			#address-cells = <1>;
 			#size-cells = <1>;
-
-			tcpwm1_0: tcpwm1_0@40388000 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40388000 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter1_0: counter1_0 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <616 4>;
+			tcpwm1_grp0: tcpwm@40580000 {
+				reg = <0x40580000 0x2A00>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+				tcpwm1_grp0_pwm: pwm@40580000 {
+					compatible = "infineon,cat1-pwm";
+					reg = <0x40580000 0x2A00>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+					#pwm-cells = <3>;
+					resolution = <16>;
 					status = "disabled";
+
+					pwm1_ch0_0: channel@0 {
+						reg = <0x0>;
+						system-interrupts = <435 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_1: channel@1 {
+						reg = <0x1>;
+						system-interrupts = <436 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_2: channel@2 {
+						reg = <0x2>;
+						system-interrupts = <437 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_3: channel@3 {
+						reg = <0x3>;
+						system-interrupts = <438 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_4: channel@4 {
+						reg = <0x4>;
+						system-interrupts = <439 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_5: channel@5 {
+						reg = <0x5>;
+						system-interrupts = <440 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_6: channel@6 {
+						reg = <0x6>;
+						system-interrupts = <441 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_7: channel@7 {
+						reg = <0x7>;
+						system-interrupts = <442 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_8: channel@8 {
+						reg = <0x8>;
+						system-interrupts = <443 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_9: channel@9 {
+						reg = <0x9>;
+						system-interrupts = <444 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_10: channel@10 {
+						reg = <0xA>;
+						system-interrupts = <445 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_11: channel@11 {
+						reg = <0xB>;
+						system-interrupts = <446 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_12: channel@12 {
+						reg = <0xC>;
+						system-interrupts = <447 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_13: channel@13 {
+						reg = <0xD>;
+						system-interrupts = <448 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_14: channel@14 {
+						reg = <0xE>;
+						system-interrupts = <449 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_15: channel@15 {
+						reg = <0xF>;
+						system-interrupts = <450 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_16: channel@16 {
+						reg = <0x10>;
+						system-interrupts = <451 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_17: channel@17 {
+						reg = <0x11>;
+						system-interrupts = <452 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_18: channel@18 {
+						reg = <0x12>;
+						system-interrupts = <453 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_19: channel@19 {
+						reg = <0x13>;
+						system-interrupts = <454 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_20: channel@20 {
+						reg = <0x14>;
+						system-interrupts = <455 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_21: channel@21 {
+						reg = <0x15>;
+						system-interrupts = <456 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_22: channel@22 {
+						reg = <0x16>;
+						system-interrupts = <457 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_23: channel@23 {
+						reg = <0x17>;
+						system-interrupts = <458 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_24: channel@24 {
+						reg = <0x18>;
+						system-interrupts = <459 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_25: channel@25 {
+						reg = <0x19>;
+						system-interrupts = <460 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_26: channel@26 {
+						reg = <0x1A>;
+						system-interrupts = <461 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_27: channel@27 {
+						reg = <0x1B>;
+						system-interrupts = <462 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_28: channel@28 {
+						reg = <0x1C>;
+						system-interrupts = <463 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_29: channel@29 {
+						reg = <0x1D>;
+						system-interrupts = <464 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_30: channel@30 {
+						reg = <0x1E>;
+						system-interrupts = <465 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_31: channel@31 {
+						reg = <0x1F>;
+						system-interrupts = <466 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_32: channel@32 {
+						reg = <0x20>;
+						system-interrupts = <467 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_33: channel@33 {
+						reg = <0x21>;
+						system-interrupts = <468 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_34: channel@34 {
+						reg = <0x22>;
+						system-interrupts = <469 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_35: channel@35 {
+						reg = <0x23>;
+						system-interrupts = <470 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_36: channel@36 {
+						reg = <0x24>;
+						system-interrupts = <471 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_37: channel@37 {
+						reg = <0x25>;
+						system-interrupts = <472 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_38: channel@38 {
+						reg = <0x26>;
+						system-interrupts = <473 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_39: channel@39 {
+						reg = <0x27>;
+						system-interrupts = <474 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_40: channel@40 {
+						reg = <0x28>;
+						system-interrupts = <475 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_41: channel@41 {
+						reg = <0x29>;
+						system-interrupts = <476 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_42: channel@42 {
+						reg = <0x2A>;
+						system-interrupts = <477 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_43: channel@43 {
+						reg = <0x2B>;
+						system-interrupts = <478 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_44: channel@44 {
+						reg = <0x2C>;
+						system-interrupts = <479 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_45: channel@45 {
+						reg = <0x2D>;
+						system-interrupts = <480 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_46: channel@46 {
+						reg = <0x2E>;
+						system-interrupts = <481 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_47: channel@47 {
+						reg = <0x2F>;
+						system-interrupts = <482 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_48: channel@48 {
+						reg = <0x30>;
+						system-interrupts = <483 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_49: channel@49 {
+						reg = <0x31>;
+						system-interrupts = <484 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_50: channel@50 {
+						reg = <0x32>;
+						system-interrupts = <485 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_51: channel@51 {
+						reg = <0x33>;
+						system-interrupts = <486 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_52: channel@52 {
+						reg = <0x34>;
+						system-interrupts = <487 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_53: channel@53 {
+						reg = <0x35>;
+						system-interrupts = <488 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_54: channel@54 {
+						reg = <0x36>;
+						system-interrupts = <489 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_55: channel@55 {
+						reg = <0x37>;
+						system-interrupts = <490 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_56: channel@56 {
+						reg = <0x38>;
+						system-interrupts = <491 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_57: channel@57 {
+						reg = <0x39>;
+						system-interrupts = <492 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_58: channel@58 {
+						reg = <0x3A>;
+						system-interrupts = <493 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_59: channel@59 {
+						reg = <0x3B>;
+						system-interrupts = <494 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_60: channel@60 {
+						reg = <0x3C>;
+						system-interrupts = <495 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_61: channel@61 {
+						reg = <0x3D>;
+						system-interrupts = <496 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_62: channel@62 {
+						reg = <0x3E>;
+						system-interrupts = <497 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_63: channel@63 {
+						reg = <0x3F>;
+						system-interrupts = <498 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_64: channel@64 {
+						reg = <0x40>;
+						system-interrupts = <499 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_65: channel@65 {
+						reg = <0x41>;
+						system-interrupts = <500 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_66: channel@66 {
+						reg = <0x42>;
+						system-interrupts = <501 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_67: channel@67 {
+						reg = <0x43>;
+						system-interrupts = <502 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_68: channel@68 {
+						reg = <0x44>;
+						system-interrupts = <503 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_69: channel@69 {
+						reg = <0x45>;
+						system-interrupts = <504 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_70: channel@70 {
+						reg = <0x46>;
+						system-interrupts = <505 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_71: channel@71 {
+						reg = <0x47>;
+						system-interrupts = <506 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_72: channel@72 {
+						reg = <0x48>;
+						system-interrupts = <507 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_73: channel@73 {
+						reg = <0x49>;
+						system-interrupts = <508 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_74: channel@74 {
+						reg = <0x4A>;
+						system-interrupts = <509 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_75: channel@75 {
+						reg = <0x4B>;
+						system-interrupts = <510 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_76: channel@76 {
+						reg = <0x4C>;
+						system-interrupts = <511 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_77: channel@77 {
+						reg = <0x4D>;
+						system-interrupts = <512 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_78: channel@78 {
+						reg = <0x4E>;
+						system-interrupts = <513 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_79: channel@79 {
+						reg = <0x4F>;
+						system-interrupts = <514 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_80: channel@80 {
+						reg = <0x50>;
+						system-interrupts = <515 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_81: channel@81 {
+						reg = <0x51>;
+						system-interrupts = <516 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_82: channel@82 {
+						reg = <0x52>;
+						system-interrupts = <517 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch0_83: channel@83 {
+						reg = <0x53>;
+						system-interrupts = <518 4>;
+						status = "disabled";
+					};
 				};
 
-				pwm1_0: pwm1_0 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <616 4>;
-					#pwm-cells = <3>;
+				tcpwm1_grp0_tgpio: tgpio@40580000 {
+					compatible = "infineon,tcpwm-tgpio";
+					reg = <0x40580000 0x2A00>;
+					#address-cells = <1>;
+					#size-cells = <0>;
 					status = "disabled";
+
+					tgpio1_ch0_0: channel@0 {
+						reg = <0x0>;
+						system-interrupts = <435 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_1: channel@1 {
+						reg = <0x1>;
+						system-interrupts = <436 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_2: channel@2 {
+						reg = <0x2>;
+						system-interrupts = <437 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_3: channel@3 {
+						reg = <0x3>;
+						system-interrupts = <438 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_4: channel@4 {
+						reg = <0x4>;
+						system-interrupts = <439 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_5: channel@5 {
+						reg = <0x5>;
+						system-interrupts = <440 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_6: channel@6 {
+						reg = <0x6>;
+						system-interrupts = <441 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_7: channel@7 {
+						reg = <0x7>;
+						system-interrupts = <442 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_8: channel@8 {
+						reg = <0x8>;
+						system-interrupts = <443 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_9: channel@9 {
+						reg = <0x9>;
+						system-interrupts = <444 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_10: channel@10 {
+						reg = <0xA>;
+						system-interrupts = <445 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_11: channel@11 {
+						reg = <0xB>;
+						system-interrupts = <446 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_12: channel@12 {
+						reg = <0xC>;
+						system-interrupts = <447 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_13: channel@13 {
+						reg = <0xD>;
+						system-interrupts = <448 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_14: channel@14 {
+						reg = <0xE>;
+						system-interrupts = <449 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_15: channel@15 {
+						reg = <0xF>;
+						system-interrupts = <450 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_16: channel@16 {
+						reg = <0x10>;
+						system-interrupts = <451 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_17: channel@17 {
+						reg = <0x11>;
+						system-interrupts = <452 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_18: channel@18 {
+						reg = <0x12>;
+						system-interrupts = <453 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_19: channel@19 {
+						reg = <0x13>;
+						system-interrupts = <454 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_20: channel@20 {
+						reg = <0x14>;
+						system-interrupts = <455 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_21: channel@21 {
+						reg = <0x15>;
+						system-interrupts = <456 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_22: channel@22 {
+						reg = <0x16>;
+						system-interrupts = <457 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_23: channel@23 {
+						reg = <0x17>;
+						system-interrupts = <458 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_24: channel@24 {
+						reg = <0x18>;
+						system-interrupts = <459 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_25: channel@25 {
+						reg = <0x19>;
+						system-interrupts = <460 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_26: channel@26 {
+						reg = <0x1A>;
+						system-interrupts = <461 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_27: channel@27 {
+						reg = <0x1B>;
+						system-interrupts = <462 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_28: channel@28 {
+						reg = <0x1C>;
+						system-interrupts = <463 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_29: channel@29 {
+						reg = <0x1D>;
+						system-interrupts = <464 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_30: channel@30 {
+						reg = <0x1E>;
+						system-interrupts = <465 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_31: channel@31 {
+						reg = <0x1F>;
+						system-interrupts = <466 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_32: channel@32 {
+						reg = <0x20>;
+						system-interrupts = <467 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_33: channel@33 {
+						reg = <0x21>;
+						system-interrupts = <468 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_34: channel@34 {
+						reg = <0x22>;
+						system-interrupts = <469 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_35: channel@35 {
+						reg = <0x23>;
+						system-interrupts = <470 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_36: channel@36 {
+						reg = <0x24>;
+						system-interrupts = <471 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_37: channel@37 {
+						reg = <0x25>;
+						system-interrupts = <472 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_38: channel@38 {
+						reg = <0x26>;
+						system-interrupts = <473 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_39: channel@39 {
+						reg = <0x27>;
+						system-interrupts = <474 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_40: channel@40 {
+						reg = <0x28>;
+						system-interrupts = <475 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_41: channel@41 {
+						reg = <0x29>;
+						system-interrupts = <476 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_42: channel@42 {
+						reg = <0x2A>;
+						system-interrupts = <477 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_43: channel@43 {
+						reg = <0x2B>;
+						system-interrupts = <478 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_44: channel@44 {
+						reg = <0x2C>;
+						system-interrupts = <479 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_45: channel@45 {
+						reg = <0x2D>;
+						system-interrupts = <480 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_46: channel@46 {
+						reg = <0x2E>;
+						system-interrupts = <481 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_47: channel@47 {
+						reg = <0x2F>;
+						system-interrupts = <482 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_48: channel@48 {
+						reg = <0x30>;
+						system-interrupts = <483 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_49: channel@49 {
+						reg = <0x31>;
+						system-interrupts = <484 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_50: channel@50 {
+						reg = <0x32>;
+						system-interrupts = <485 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_51: channel@51 {
+						reg = <0x33>;
+						system-interrupts = <486 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_52: channel@52 {
+						reg = <0x34>;
+						system-interrupts = <487 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_53: channel@53 {
+						reg = <0x35>;
+						system-interrupts = <488 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_54: channel@54 {
+						reg = <0x36>;
+						system-interrupts = <489 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_55: channel@55 {
+						reg = <0x37>;
+						system-interrupts = <490 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_56: channel@56 {
+						reg = <0x38>;
+						system-interrupts = <491 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_57: channel@57 {
+						reg = <0x39>;
+						system-interrupts = <492 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_58: channel@58 {
+						reg = <0x3A>;
+						system-interrupts = <493 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_59: channel@59 {
+						reg = <0x3B>;
+						system-interrupts = <494 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_60: channel@60 {
+						reg = <0x3C>;
+						system-interrupts = <495 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_61: channel@61 {
+						reg = <0x3D>;
+						system-interrupts = <496 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_62: channel@62 {
+						reg = <0x3E>;
+						system-interrupts = <497 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_63: channel@63 {
+						reg = <0x3F>;
+						system-interrupts = <498 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_64: channel@64 {
+						reg = <0x40>;
+						system-interrupts = <499 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_65: channel@65 {
+						reg = <0x41>;
+						system-interrupts = <500 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_66: channel@66 {
+						reg = <0x42>;
+						system-interrupts = <501 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_67: channel@67 {
+						reg = <0x43>;
+						system-interrupts = <502 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_68: channel@68 {
+						reg = <0x44>;
+						system-interrupts = <503 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_69: channel@69 {
+						reg = <0x45>;
+						system-interrupts = <504 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_70: channel@70 {
+						reg = <0x46>;
+						system-interrupts = <505 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_71: channel@71 {
+						reg = <0x47>;
+						system-interrupts = <506 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_72: channel@72 {
+						reg = <0x48>;
+						system-interrupts = <507 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_73: channel@73 {
+						reg = <0x49>;
+						system-interrupts = <508 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_74: channel@74 {
+						reg = <0x4A>;
+						system-interrupts = <509 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_75: channel@75 {
+						reg = <0x4B>;
+						system-interrupts = <510 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_76: channel@76 {
+						reg = <0x4C>;
+						system-interrupts = <511 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_77: channel@77 {
+						reg = <0x4D>;
+						system-interrupts = <512 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_78: channel@78 {
+						reg = <0x4E>;
+						system-interrupts = <513 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_79: channel@79 {
+						reg = <0x4F>;
+						system-interrupts = <514 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_80: channel@80 {
+						reg = <0x50>;
+						system-interrupts = <515 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_81: channel@81 {
+						reg = <0x51>;
+						system-interrupts = <516 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_82: channel@82 {
+						reg = <0x52>;
+						system-interrupts = <517 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch0_83: channel@83 {
+						reg = <0x53>;
+						system-interrupts = <518 4>;
+						status = "disabled";
+					};
+				};
+
+				tcpwm1_grp0_cnt: tcpwm@40580000 {
+					compatible = "infineon,tcpwm";
+					reg = <0x40580000 0x2A00>;
+					#address-cells = <1>;
+					#size-cells = <1>;
+					resolution = <16>;
+					status = "disabled";
+
+					counter1_0_0: counter@40580000 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580000 0x80>;
+						system-interrupts = <435 4>;
+						status = "disabled";
+					};
+
+					counter1_0_1: counter@40580080 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580080 0x80>;
+						system-interrupts = <436 4>;
+						status = "disabled";
+					};
+
+					counter1_0_2: counter@40580100 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580100 0x80>;
+						system-interrupts = <437 4>;
+						status = "disabled";
+					};
+
+					counter1_0_3: counter@40580180 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580180 0x80>;
+						system-interrupts = <438 4>;
+						status = "disabled";
+					};
+
+					counter1_0_4: counter@40580200 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580200 0x80>;
+						system-interrupts = <439 4>;
+						status = "disabled";
+					};
+
+					counter1_0_5: counter@40580280 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580280 0x80>;
+						system-interrupts = <440 4>;
+						status = "disabled";
+					};
+
+					counter1_0_6: counter@40580300 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580300 0x80>;
+						system-interrupts = <441 4>;
+						status = "disabled";
+					};
+
+					counter1_0_7: counter@40580380 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580380 0x80>;
+						system-interrupts = <442 4>;
+						status = "disabled";
+					};
+
+					counter1_0_8: counter@40580400 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580400 0x80>;
+						system-interrupts = <443 4>;
+						status = "disabled";
+					};
+
+					counter1_0_9: counter@40580480 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580480 0x80>;
+						system-interrupts = <444 4>;
+						status = "disabled";
+					};
+
+					counter1_0_10: counter@40580500 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580500 0x80>;
+						system-interrupts = <445 4>;
+						status = "disabled";
+					};
+
+					counter1_0_11: counter@40580580 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580580 0x80>;
+						system-interrupts = <446 4>;
+						status = "disabled";
+					};
+
+					counter1_0_12: counter@40580600 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580600 0x80>;
+						system-interrupts = <447 4>;
+						status = "disabled";
+					};
+
+					counter1_0_13: counter@40580680 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580680 0x80>;
+						system-interrupts = <448 4>;
+						status = "disabled";
+					};
+
+					counter1_0_14: counter@40580700 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580700 0x80>;
+						system-interrupts = <449 4>;
+						status = "disabled";
+					};
+
+					counter1_0_15: counter@40580780 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580780 0x80>;
+						system-interrupts = <450 4>;
+						status = "disabled";
+					};
+
+					counter1_0_16: counter@40580800 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580800 0x80>;
+						system-interrupts = <451 4>;
+						status = "disabled";
+					};
+
+					counter1_0_17: counter@40580880 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580880 0x80>;
+						system-interrupts = <452 4>;
+						status = "disabled";
+					};
+
+					counter1_0_18: counter@40580900 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580900 0x80>;
+						system-interrupts = <453 4>;
+						status = "disabled";
+					};
+
+					counter1_0_19: counter@40580980 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580980 0x80>;
+						system-interrupts = <454 4>;
+						status = "disabled";
+					};
+
+					counter1_0_20: counter@40580a00 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580a00 0x80>;
+						system-interrupts = <455 4>;
+						status = "disabled";
+					};
+
+					counter1_0_21: counter@40580a80 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580a80 0x80>;
+						system-interrupts = <456 4>;
+						status = "disabled";
+					};
+
+					counter1_0_22: counter@40580b00 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580b00 0x80>;
+						system-interrupts = <457 4>;
+						status = "disabled";
+					};
+
+					counter1_0_23: counter@40580b80 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580b80 0x80>;
+						system-interrupts = <458 4>;
+						status = "disabled";
+					};
+
+					counter1_0_24: counter@40580c00 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580c00 0x80>;
+						system-interrupts = <459 4>;
+						status = "disabled";
+					};
+
+					counter1_0_25: counter@40580c80 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580c80 0x80>;
+						system-interrupts = <460 4>;
+						status = "disabled";
+					};
+
+					counter1_0_26: counter@40580d00 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580d00 0x80>;
+						system-interrupts = <461 4>;
+						status = "disabled";
+					};
+
+					counter1_0_27: counter@40580d80 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580d80 0x80>;
+						system-interrupts = <462 4>;
+						status = "disabled";
+					};
+
+					counter1_0_28: counter@40580e00 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580e00 0x80>;
+						system-interrupts = <463 4>;
+						status = "disabled";
+					};
+
+					counter1_0_29: counter@40580e80 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580e80 0x80>;
+						system-interrupts = <464 4>;
+						status = "disabled";
+					};
+
+					counter1_0_30: counter@40580f00 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580f00 0x80>;
+						system-interrupts = <465 4>;
+						status = "disabled";
+					};
+
+					counter1_0_31: counter@40580f80 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40580f80 0x80>;
+						system-interrupts = <466 4>;
+						status = "disabled";
+					};
+
+					counter1_0_32: counter@40581000 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581000 0x80>;
+						system-interrupts = <467 4>;
+						status = "disabled";
+					};
+
+					counter1_0_33: counter@40581080 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581080 0x80>;
+						system-interrupts = <468 4>;
+						status = "disabled";
+					};
+
+					counter1_0_34: counter@40581100 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581100 0x80>;
+						system-interrupts = <469 4>;
+						status = "disabled";
+					};
+
+					counter1_0_35: counter@40581180 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581180 0x80>;
+						system-interrupts = <470 4>;
+						status = "disabled";
+					};
+
+					counter1_0_36: counter@40581200 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581200 0x80>;
+						system-interrupts = <471 4>;
+						status = "disabled";
+					};
+
+					counter1_0_37: counter@40581280 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581280 0x80>;
+						system-interrupts = <472 4>;
+						status = "disabled";
+					};
+
+					counter1_0_38: counter@40581300 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581300 0x80>;
+						system-interrupts = <473 4>;
+						status = "disabled";
+					};
+
+					counter1_0_39: counter@40581380 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581380 0x80>;
+						system-interrupts = <474 4>;
+						status = "disabled";
+					};
+
+					counter1_0_40: counter@40581400 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581400 0x80>;
+						system-interrupts = <475 4>;
+						status = "disabled";
+					};
+
+					counter1_0_41: counter@40581480 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581480 0x80>;
+						system-interrupts = <476 4>;
+						status = "disabled";
+					};
+
+					counter1_0_42: counter@40581500 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581500 0x80>;
+						system-interrupts = <477 4>;
+						status = "disabled";
+					};
+
+					counter1_0_43: counter@40581580 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581580 0x80>;
+						system-interrupts = <478 4>;
+						status = "disabled";
+					};
+
+					counter1_0_44: counter@40581600 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581600 0x80>;
+						system-interrupts = <479 4>;
+						status = "disabled";
+					};
+
+					counter1_0_45: counter@40581680 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581680 0x80>;
+						system-interrupts = <480 4>;
+						status = "disabled";
+					};
+
+					counter1_0_46: counter@40581700 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581700 0x80>;
+						system-interrupts = <481 4>;
+						status = "disabled";
+					};
+
+					counter1_0_47: counter@40581780 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581780 0x80>;
+						system-interrupts = <482 4>;
+						status = "disabled";
+					};
+
+					counter1_0_48: counter@40581800 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581800 0x80>;
+						system-interrupts = <483 4>;
+						status = "disabled";
+					};
+
+					counter1_0_49: counter@40581880 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581880 0x80>;
+						system-interrupts = <484 4>;
+						status = "disabled";
+					};
+
+					counter1_0_50: counter@40581900 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581900 0x80>;
+						system-interrupts = <485 4>;
+						status = "disabled";
+					};
+
+					counter1_0_51: counter@40581980 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581980 0x80>;
+						system-interrupts = <486 4>;
+						status = "disabled";
+					};
+
+					counter1_0_52: counter@40581a00 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581a00 0x80>;
+						system-interrupts = <487 4>;
+						status = "disabled";
+					};
+
+					counter1_0_53: counter@40581a80 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581a80 0x80>;
+						system-interrupts = <488 4>;
+						status = "disabled";
+					};
+
+					counter1_0_54: counter@40581b00 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581b00 0x80>;
+						system-interrupts = <489 4>;
+						status = "disabled";
+					};
+
+					counter1_0_55: counter@40581b80 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581b80 0x80>;
+						system-interrupts = <490 4>;
+						status = "disabled";
+					};
+
+					counter1_0_56: counter@40581c00 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581c00 0x80>;
+						system-interrupts = <491 4>;
+						status = "disabled";
+					};
+
+					counter1_0_57: counter@40581c80 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581c80 0x80>;
+						system-interrupts = <492 4>;
+						status = "disabled";
+					};
+
+					counter1_0_58: counter@40581d00 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581d00 0x80>;
+						system-interrupts = <493 4>;
+						status = "disabled";
+					};
+
+					counter1_0_59: counter@40581d80 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581d80 0x80>;
+						system-interrupts = <494 4>;
+						status = "disabled";
+					};
+
+					counter1_0_60: counter@40581e00 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581e00 0x80>;
+						system-interrupts = <495 4>;
+						status = "disabled";
+					};
+
+					counter1_0_61: counter@40581e80 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581e80 0x80>;
+						system-interrupts = <496 4>;
+						status = "disabled";
+					};
+
+					counter1_0_62: counter@40581f00 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581f00 0x80>;
+						system-interrupts = <497 4>;
+						status = "disabled";
+					};
+
+					counter1_0_63: counter@40581f80 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40581f80 0x80>;
+						system-interrupts = <498 4>;
+						status = "disabled";
+					};
+
+					counter1_0_64: counter@40582000 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40582000 0x80>;
+						system-interrupts = <499 4>;
+						status = "disabled";
+					};
+
+					counter1_0_65: counter@40582080 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40582080 0x80>;
+						system-interrupts = <500 4>;
+						status = "disabled";
+					};
+
+					counter1_0_66: counter@40582100 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40582100 0x80>;
+						system-interrupts = <501 4>;
+						status = "disabled";
+					};
+
+					counter1_0_67: counter@40582180 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40582180 0x80>;
+						system-interrupts = <502 4>;
+						status = "disabled";
+					};
+
+					counter1_0_68: counter@40582200 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40582200 0x80>;
+						system-interrupts = <503 4>;
+						status = "disabled";
+					};
+
+					counter1_0_69: counter@40582280 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40582280 0x80>;
+						system-interrupts = <504 4>;
+						status = "disabled";
+					};
+
+					counter1_0_70: counter@40582300 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40582300 0x80>;
+						system-interrupts = <505 4>;
+						status = "disabled";
+					};
+
+					counter1_0_71: counter@40582380 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40582380 0x80>;
+						system-interrupts = <506 4>;
+						status = "disabled";
+					};
+
+					counter1_0_72: counter@40582400 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40582400 0x80>;
+						system-interrupts = <507 4>;
+						status = "disabled";
+					};
+
+					counter1_0_73: counter@40582480 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40582480 0x80>;
+						system-interrupts = <508 4>;
+						status = "disabled";
+					};
+
+					counter1_0_74: counter@40582500 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40582500 0x80>;
+						system-interrupts = <509 4>;
+						status = "disabled";
+					};
+
+					counter1_0_75: counter@40582580 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40582580 0x80>;
+						system-interrupts = <510 4>;
+						status = "disabled";
+					};
+
+					counter1_0_76: counter@40582600 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40582600 0x80>;
+						system-interrupts = <511 4>;
+						status = "disabled";
+					};
+
+					counter1_0_77: counter@40582680 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40582680 0x80>;
+						system-interrupts = <512 4>;
+						status = "disabled";
+					};
+
+					counter1_0_78: counter@40582700 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40582700 0x80>;
+						system-interrupts = <513 4>;
+						status = "disabled";
+					};
+
+					counter1_0_79: counter@40582780 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40582780 0x80>;
+						system-interrupts = <514 4>;
+						status = "disabled";
+					};
+
+					counter1_0_80: counter@40582800 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40582800 0x80>;
+						system-interrupts = <515 4>;
+						status = "disabled";
+					};
+
+					counter1_0_81: counter@40582880 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40582880 0x80>;
+						system-interrupts = <516 4>;
+						status = "disabled";
+					};
+
+					counter1_0_82: counter@40582900 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40582900 0x80>;
+						system-interrupts = <517 4>;
+						status = "disabled";
+					};
+
+					counter1_0_83: counter@40582980 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40582980 0x80>;
+						system-interrupts = <518 4>;
+						status = "disabled";
+					};
 				};
 			};
 
-			tcpwm1_1: tcpwm1_1@40388080 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40388080 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter1_1: counter1_1 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <617 4>;
+			tcpwm1_grp1: tcpwm@40588000 {
+				reg = <0x40588000 0x600>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+				tcpwm1_grp1_pwm: pwm@40588000 {
+					compatible = "infineon,cat1-pwm";
+					reg = <0x40588000 0x600>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+					#pwm-cells = <3>;
+					resolution = <16>;
 					status = "disabled";
+
+					pwm1_ch1_0: channel@0 {
+						reg = <0x0>;
+						system-interrupts = <522 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch1_1: channel@1 {
+						reg = <0x1>;
+						system-interrupts = <523 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch1_2: channel@2 {
+						reg = <0x2>;
+						system-interrupts = <524 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch1_3: channel@3 {
+						reg = <0x3>;
+						system-interrupts = <525 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch1_4: channel@4 {
+						reg = <0x4>;
+						system-interrupts = <526 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch1_5: channel@5 {
+						reg = <0x5>;
+						system-interrupts = <527 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch1_6: channel@6 {
+						reg = <0x6>;
+						system-interrupts = <527 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch1_7: channel@7 {
+						reg = <0x7>;
+						system-interrupts = <529 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch1_8: channel@8 {
+						reg = <0x8>;
+						system-interrupts = <530 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch1_9: channel@9 {
+						reg = <0x9>;
+						system-interrupts = <531 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch1_10: channel@10 {
+						reg = <0xA>;
+						system-interrupts = <532 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch1_11: channel@11 {
+						reg = <0xB>;
+						system-interrupts = <533 4>;
+						status = "disabled";
+					};
 				};
 
-				pwm1_1: pwm1_1 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <617 4>;
-					#pwm-cells = <3>;
+				tcpwm1_grp1_cnt: tcpwm@40588000 {
+					compatible = "infineon,tcpwm";
+					reg = <0x40588000 0x600>;
+					#address-cells = <1>;
+					#size-cells = <1>;
+					resolution = <16>;
 					status = "disabled";
+
+					counter1_1_0: counter@40588000 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40588000 0x80>;
+						system-interrupts = <522 4>;
+						status = "disabled";
+					};
+
+					counter1_1_1: counter@40588080 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40588080 0x80>;
+						system-interrupts = <523 4>;
+						status = "disabled";
+					};
+
+					counter1_1_2: counter@40588100 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40588100 0x80>;
+						system-interrupts = <524 4>;
+						status = "disabled";
+					};
+
+					counter1_1_3: counter@40588180 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40588180 0x80>;
+						system-interrupts = <525 4>;
+						status = "disabled";
+					};
+
+					counter1_1_4: counter@40588200 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40588200 0x80>;
+						system-interrupts = <526 4>;
+						status = "disabled";
+					};
+
+					counter1_1_5: counter@40588280 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40588280 0x80>;
+						system-interrupts = <527 4>;
+						status = "disabled";
+					};
+
+					counter1_1_6: counter@40588300 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40588300 0x80>;
+						system-interrupts = <528 4>;
+						status = "disabled";
+					};
+
+					counter1_1_7: counter@40588380 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40588380 0x80>;
+						system-interrupts = <529 4>;
+						status = "disabled";
+					};
+
+					counter1_1_8: counter@40588400 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40588400 0x80>;
+						system-interrupts = <530 4>;
+						status = "disabled";
+					};
+
+					counter1_1_9: counter@40588480 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40588480 0x80>;
+						system-interrupts = <531 4>;
+						status = "disabled";
+					};
+
+					counter1_1_10: counter@40588500 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40588500 0x80>;
+						system-interrupts = <532 4>;
+						status = "disabled";
+					};
+
+					counter1_1_11: counter@40588580 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40588580 0x80>;
+						system-interrupts = <533 4>;
+						status = "disabled";
+					};
 				};
 			};
 
-			tcpwm1_2: tcpwm1_2@40388100 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40388100 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter1_2: counter1_2 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <618 4>;
-					status = "disabled";
-				};
-
-				pwm1_2: pwm1_2 {
+			tcpwm1_grp2: tcpwm@40590000 {
+				reg = <0x40590000 0x680>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+				tcpwm1_grp2_pwm: pwm@40590000 {
 					compatible = "infineon,cat1-pwm";
-					system-interrupts = <618 4>;
+					reg = <0x40590000 0x680>;
+					#address-cells = <1>;
+					#size-cells = <0>;
 					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm1_3: tcpwm1_3@40388180 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40388180 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter1_3: counter1_3 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <619 4>;
-					status = "disabled";
-				};
-
-				pwm1_3: pwm1_3 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <619 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm1_4: tcpwm1_4@40388200 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40388200 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter1_4: counter1_4 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <620 4>;
-					status = "disabled";
-				};
-
-				pwm1_4: pwm1_4 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <620 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm1_5: tcpwm1_5@40388280 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40388280 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter1_5: counter1_5 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <621 4>;
-					status = "disabled";
-				};
-
-				pwm1_5: pwm1_5 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <621 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm1_6: tcpwm1_6@40388300 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40388300 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter1_6: counter1_6 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <622 4>;
-					status = "disabled";
-				};
-
-				pwm1_6: pwm1_6 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <622 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm1_7: tcpwm1_7@40388380 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40388380 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter1_7: counter1_7 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <623 4>;
-					status = "disabled";
-				};
-
-				pwm1_7: pwm1_7 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <623 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm1_8: tcpwm1_8@40388400 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40388400 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter1_8: counter1_8 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <624 4>;
-					status = "disabled";
-				};
-
-				pwm1_8: pwm1_8 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <624 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm1_9: tcpwm1_9@40388480 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40388480 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter1_9: counter1_9 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <625 4>;
-					status = "disabled";
-				};
-
-				pwm1_9: pwm1_9 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <625 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm1_10: tcpwm1_10@40388500 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40388500 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter1_10: counter1_10 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <626 4>;
-					status = "disabled";
-				};
-
-				pwm1_10: pwm1_10 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <626 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm1_11: tcpwm1_11@40388580 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40388580 0x80>;
-				resolution = <16>;
-				status = "disabled";
-
-				counter1_11: counter1_11 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <627 4>;
-					status = "disabled";
-				};
-
-				pwm1_11: pwm1_11 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <627 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-		};
-
-		tcpwm0_grp2: tcpwm0@40390000 {
-			reg = <0x40390000 0x80>;
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			tcpwm2_0: tcpwm2_0@40390000 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390000 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_0: counter2_0 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <680 4>;
-					status = "disabled";
-				};
-
-				pwm2_0: pwm2_0 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <680 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm2_1: tcpwm2_1@40390080 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390080 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_1: counter2_1 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <681 4>;
-					status = "disabled";
-				};
-
-				pwm2_1: pwm2_1 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <681 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm2_2: tcpwm2_2@40390100 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390100 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_2: counter2_2 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <682 4>;
-					status = "disabled";
-				};
-
-				pwm2_2: pwm2_2 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <682 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm2_3: tcpwm2_3@40390180 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390180 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_3: counter2_3 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <683 4>;
-					status = "disabled";
-				};
-
-				pwm2_3: pwm2_3 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <683 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm2_4: tcpwm2_4@40390200 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390200 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_4: counter2_4 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <684 4>;
-					status = "disabled";
-				};
-
-				pwm2_4: pwm2_4 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <684 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm2_5: tcpwm2_5@40390280 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390280 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_5: counter2_5 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <685 4>;
-					status = "disabled";
-				};
-
-				pwm2_5: pwm2_5 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <685 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm2_6: tcpwm2_6@40390300 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390300 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_6: counter2_6 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <686 4>;
-					status = "disabled";
-				};
-
-				pwm2_6: pwm2_6 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <686 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm2_7: tcpwm2_7@40390380 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390380 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_7: counter2_7 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <687 4>;
-					status = "disabled";
-				};
-
-				pwm2_7: pwm2_7 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <687 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm2_8: tcpwm2_8@40390400 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390400 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_8: counter2_8 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <688 4>;
-					status = "disabled";
-				};
-
-				pwm2_8: pwm2_8 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <688 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm2_9: tcpwm2_9@40390480 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390480 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_9: counter2_9 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <689 4>;
-					status = "disabled";
-				};
-
-				pwm2_9: pwm2_9 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <689 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm2_10: tcpwm2_10@40390500 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390500 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_10: counter2_10 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <690 4>;
-					status = "disabled";
-				};
-
-				pwm2_10: pwm2_10 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <690 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm2_11: tcpwm2_11@40390580 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390580 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_11: counter2_11 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <691 4>;
-					status = "disabled";
-				};
-
-				pwm2_11: pwm2_11 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <691 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm2_12: tcpwm2_12@40390600 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390600 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_12: counter2_12 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <692 4>;
-					status = "disabled";
-				};
-
-				pwm2_12: pwm2_12 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <692 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm2_13: tcpwm2_13@40390680 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390680 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_13: counter2_13 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <693 4>;
-					status = "disabled";
-				};
-
-				pwm2_13: pwm2_13 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <693 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm2_14: tcpwm2_14@40390700 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390700 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_14: counter2_14 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <694 4>;
-					status = "disabled";
-				};
-
-				pwm2_14: pwm2_14 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <694 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm2_15: tcpwm2_15@40390780 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390780 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_15: counter2_15 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <695 4>;
-					status = "disabled";
-				};
-
-				pwm2_15: pwm2_15 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <695 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm2_16: tcpwm2_16@40390800 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390800 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_16: counter2_16 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <696 4>;
-					status = "disabled";
-				};
-
-				pwm2_16: pwm2_16 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <696 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm2_17: tcpwm2_17@40390880 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390880 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_17: counter2_17 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <697 4>;
-					status = "disabled";
-				};
-
-				pwm2_17: pwm2_17 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <697 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm2_18: tcpwm2_18@40390900 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390900 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_18: counter2_18 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <698 4>;
-					status = "disabled";
-				};
-
-				pwm2_18: pwm2_18 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <698 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm2_19: tcpwm2_19@40390980 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390980 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_19: counter2_19 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <699 4>;
-					status = "disabled";
-				};
-
-				pwm2_19: pwm2_19 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <699 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm2_20: tcpwm2_20@40390A00 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390A00 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_20: counter2_20 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <700 4>;
-					status = "disabled";
-				};
-
-				pwm2_20: pwm2_20 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <700 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm2_21: tcpwm2_21@40390A80 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390A80 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_21: counter2_21 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <701 4>;
-					status = "disabled";
-				};
-
-				pwm2_21: pwm2_21 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <701 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm2_22: tcpwm2_22@40390B00 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390B00 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_22: counter2_22 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <702 4>;
-					status = "disabled";
-				};
-
-				pwm2_22: pwm2_22 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <702 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm2_23: tcpwm2_23@40390B80 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390B80 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_23: counter2_23 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <703 4>;
-					status = "disabled";
-				};
-
-				pwm2_23: pwm2_23 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <703 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm2_24: tcpwm2_24@40390C00 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390C00 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_24: counter2_24 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <704 4>;
-					status = "disabled";
-				};
-
-				pwm2_24: pwm2_24 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <704 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm2_25: tcpwm2_25@40390C80 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390C80 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_25: counter2_25 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <705 4>;
-					status = "disabled";
-				};
-
-				pwm2_25: pwm2_25 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <705 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm2_26: tcpwm2_26@40390D00 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390D00 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_26: counter2_26 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <706 4>;
-					status = "disabled";
-				};
-
-				pwm2_26: pwm2_26 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <706 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm2_27: tcpwm2_27@40390D80 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390D80 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_27: counter2_27 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <707 4>;
-					status = "disabled";
-				};
-
-				pwm2_27: pwm2_27 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <707 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm2_28: tcpwm2_28@40390E00 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390E00 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_28: counter2_28 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <708 4>;
-					status = "disabled";
-				};
-
-				pwm2_28: pwm2_28 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <708 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm2_29: tcpwm2_29@40390E80 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390E80 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_29: counter2_29 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <709 4>;
-					status = "disabled";
-				};
-
-				pwm2_29: pwm2_29 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <709 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm2_30: tcpwm2_30@40390F00 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390F00 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_30: counter2_30 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <710 4>;
-					status = "disabled";
-				};
-
-				pwm2_30: pwm2_30 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <710 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
-				};
-			};
-
-			tcpwm2_31: tcpwm2_31@40390F80 {
-				compatible = "infineon,tcpwm";
-				reg = <0x40390F80 0x80>;
-				resolution = <32>;
-				status = "disabled";
-
-				counter2_31: counter2_31 {
-					compatible = "infineon,tcpwm-counter";
-					system-interrupts = <711 4>;
-					status = "disabled";
-				};
-
-				pwm2_31: pwm2_31 {
-					compatible = "infineon,cat1-pwm";
-					system-interrupts = <711 4>;
-					#pwm-cells = <3>;
-					status = "disabled";
+					resolution = <32>;
+					status = "disabled";
+
+					pwm1_ch2_0: channel@0 {
+						reg = <0x0>;
+						system-interrupts = <537 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch2_1: channel@1 {
+						reg = <0x1>;
+						system-interrupts = <538 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch2_2: channel@2 {
+						reg = <0x2>;
+						system-interrupts = <539 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch2_3: channel@3 {
+						reg = <0x3>;
+						system-interrupts = <540 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch2_4: channel@4 {
+						reg = <0x4>;
+						system-interrupts = <541 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch2_5: channel@5 {
+						reg = <0x5>;
+						system-interrupts = <542 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch2_6: channel@6 {
+						reg = <0x6>;
+						system-interrupts = <543 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch2_7: channel@7 {
+						reg = <0x7>;
+						system-interrupts = <544 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch2_8: channel@8 {
+						reg = <0x8>;
+						system-interrupts = <545 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch2_9: channel@9 {
+						reg = <0x9>;
+						system-interrupts = <546 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch2_10: channel@10 {
+						reg = <0xA>;
+						system-interrupts = <547 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch2_11: channel@11 {
+						reg = <0xB>;
+						system-interrupts = <548 4>;
+						status = "disabled";
+					};
+
+					pwm1_ch2_12: channel@12 {
+						reg = <0xC>;
+						system-interrupts = <549 4>;
+						status = "disabled";
+					};
+				};
+
+				tcpwm1_grp2_tgpio: tgpio@40590000 {
+					compatible = "infineon,tcpwm-tgpio";
+					reg = <0x40590000 0x680>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+					status = "disabled";
+
+					tgpio1_ch2_0: channel@0 {
+						reg = <0x0>;
+						system-interrupts = <537 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch2_1: channel@1 {
+						reg = <0x1>;
+						system-interrupts = <538 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch2_2: channel@2 {
+						reg = <0x2>;
+						system-interrupts = <539 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch2_3: channel@3 {
+						reg = <0x3>;
+						system-interrupts = <540 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch2_4: channel@4 {
+						reg = <0x4>;
+						system-interrupts = <541 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch2_5: channel@5 {
+						reg = <0x5>;
+						system-interrupts = <542 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch2_6: channel@6 {
+						reg = <0x6>;
+						system-interrupts = <543 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch2_7: channel@7 {
+						reg = <0x7>;
+						system-interrupts = <544 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch2_8: channel@8 {
+						reg = <0x8>;
+						system-interrupts = <545 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch2_9: channel@9 {
+						reg = <0x9>;
+						system-interrupts = <546 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch2_10: channel@10 {
+						reg = <0xA>;
+						system-interrupts = <547 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch2_11: channel@11 {
+						reg = <0xB>;
+						system-interrupts = <548 4>;
+						status = "disabled";
+					};
+
+					tgpio1_ch2_12: channel@12 {
+						reg = <0xC>;
+						system-interrupts = <549 4>;
+						status = "disabled";
+					};
+				};
+
+				tcpwm1_grp2_cnt: tcpwm@40590000 {
+					compatible = "infineon,tcpwm";
+					reg = <0x40590000 0x680>;
+					#address-cells = <1>;
+					#size-cells = <1>;
+					resolution = <32>;
+					status = "disabled";
+
+					counter1_2_0: counter@40590000 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40590000 0x80>;
+						system-interrupts = <537 4>;
+						status = "disabled";
+					};
+
+					counter1_2_1: counter@40590080 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40590080 0x80>;
+						system-interrupts = <538 4>;
+						status = "disabled";
+					};
+
+					counter1_2_2: counter@40590100 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40590100 0x80>;
+						system-interrupts = <539 4>;
+						status = "disabled";
+					};
+
+					counter1_2_3: counter@40590180 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40590180 0x80>;
+						system-interrupts = <540 4>;
+						status = "disabled";
+					};
+
+					counter1_2_4: counter@40590200 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40590200 0x80>;
+						system-interrupts = <541 4>;
+						status = "disabled";
+					};
+
+					counter1_2_5: counter@40590280 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40590280 0x80>;
+						system-interrupts = <542 4>;
+						status = "disabled";
+					};
+
+					counter1_2_6: counter@40590300 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40590300 0x80>;
+						system-interrupts = <543 4>;
+						status = "disabled";
+					};
+
+					counter1_2_7: counter@40590380 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40590380 0x80>;
+						system-interrupts = <544 4>;
+						status = "disabled";
+					};
+
+					counter1_2_8: counter@40590400 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40590400 0x80>;
+						system-interrupts = <545 4>;
+						status = "disabled";
+					};
+
+					counter1_2_9: counter@40590480 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40590480 0x80>;
+						system-interrupts = <546 4>;
+						status = "disabled";
+					};
+
+					counter1_2_10: counter@40590500 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40590500 0x80>;
+						system-interrupts = <547 4>;
+						status = "disabled";
+					};
+
+					counter1_2_11: counter@40590580 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40590580 0x80>;
+						system-interrupts = <548 4>;
+						status = "disabled";
+					};
+
+					counter1_2_12: counter@40590600 {
+						compatible = "infineon,tcpwm-counter";
+						reg = <0x40590600 0x80>;
+						system-interrupts = <549 4>;
+						status = "disabled";
+					};
 				};
 			};
 		};

--- a/dts/arm/infineon/cat1c/traveo2-8m/cyt4bf.dtsi
+++ b/dts/arm/infineon/cat1c/traveo2-8m/cyt4bf.dtsi
@@ -3105,6 +3105,18 @@
 			ifx,peri-div-inst = <2>;
 		};
 
+		adc1: adc@40901000 {
+			compatible = "infineon,ifx-sar";
+			reg = <0x40901000 0x1000>;
+			#io-channel-cells = <1>;
+			system-interrupts = <155 3>;
+			clock-frequency = <26670000>;
+			ifx,peri-group = <IFX_PERI_GRP_INST_SEL(1, 0)>;
+			ifx,peri-clk = <0x012B>;
+			ifx,peri-div = <0>; /* 8-bit divider */
+			ifx,peri-div-inst = <2>;
+		};
+
 		can0_0: can@40520000 {
 			compatible = "infineon,cat1-can";
 			reg = <0x40520000 0x200>, <0x40530000 0xA000>;

--- a/samples/basic/blinky_pwm/boards/cytvii_b_h_8m_320_cpu_cyt4bfcche_m7_0.overlay
+++ b/samples/basic/blinky_pwm/boards/cytvii_b_h_8m_320_cpu_cyt4bfcche_m7_0.overlay
@@ -1,0 +1,13 @@
+&tcpwm1_grp0_pwm {
+	ifx,peri-group = <IFX_PERI_GRP_INST_SEL(1, 0)>;
+	status = "okay";
+};
+
+&pwm1_ch0_18 {
+	divider-type = <1>;
+	divider-sel = <0>;
+	divider-val = <3000>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&p0_0_pwm1_18_line_out>;
+	status = "okay";
+};

--- a/samples/drivers/adc/adc_dt/boards/cytvii_b_h_8m_320_cpu_cyt4bfcche_m7_0.overlay
+++ b/samples/drivers/adc/adc_dt/boards/cytvii_b_h_8m_320_cpu_cyt4bfcche_m7_0.overlay
@@ -7,36 +7,34 @@
 
 / {
 	zephyr,user {
-		io-channels = <&adc0 0>;
+		io-channels = <&adc1 10>;
 	};
 };
 
 &pinctrl {
-/* Configure P12.6 for analog input - ADC1 channel 10 */
-p12_6_pass0_sar0_an10: p12_6_pass0_sar0_an10 {
-pinmux = <DT_CAT1_PINMUX(12, 6, HSIOM_SEL_AMUXA)>;
-};
+		/* Configure P12.6 for analog input */
+		p12_6_pass0_sar1_an10: p12_6_pass0_sar1_an10 {
+		pinmux = <DT_CAT1_PINMUX(12, 6, HSIOM_SEL_AMUXA)>;
+		};
+	};
+
+&adc1 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		pinctrl-0 = <&p12_6_pass0_sar1_an10>;
+		pinctrl-names = "default";
+
+channel@10 {
+		reg = <10>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_VDD_1";
+		zephyr,vref-mv = <3300>;
+		zephyr,input-positive = <10>;
+		zephyr,resolution = <12>;
+		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_MICROSECONDS, 1)>;
+	};
 };
 
 &gpio_prt12 {
 	status = "okay";
-};
-
-
-&adc0 {
-	#address-cells = <1>;
-	#size-cells = <0>;
-
-	pinctrl-0 = <&p12_6_pass0_sar0_an10>;
-	pinctrl-names = "default";
-
-	channel@0 {
-		reg = <0>;
-		zephyr,gain = "ADC_GAIN_1";
-		zephyr,reference = "ADC_REF_VDD_1";
-		zephyr,vref-mv = <3300>; /* VDDA = 3.3V reference */
-		zephyr,input-positive = <10>;
-		zephyr,resolution = <12>;
-		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_MICROSECONDS, 10)>;
-	};
 };

--- a/samples/drivers/counter/alarm/boards/cytvii_b_h_8m_320_cpu_cyt4bfcche_m7_0.overlay
+++ b/samples/drivers/counter/alarm/boards/cytvii_b_h_8m_320_cpu_cyt4bfcche_m7_0.overlay
@@ -1,0 +1,11 @@
+&tcpwm0_grp0_cnt {
+	ifx,peri-group = <IFX_PERI_GRP_INST_SEL(0, 0)>;
+	status = "okay";
+};
+
+&counter0_0{
+	divider-type = <1>;
+        divider-sel = <0>;
+        divider-val = <20000>;
+        status = "okay";
+};

--- a/samples/drivers/flash_driver_test_t2g/boards/cytvii_b_h_8m_320_cpu_cyt4bfcche_m7_0.overlay
+++ b/samples/drivers/flash_driver_test_t2g/boards/cytvii_b_h_8m_320_cpu_cyt4bfcche_m7_0.overlay
@@ -1,0 +1,7 @@
+&code_flash1 {
+	partitions {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "fixed-partitions";
+	};
+};

--- a/samples/drivers/misc/timeaware_gpio/boards/cytvii_b_h_8m_320_cpu_cyt4bfcche_m7_0.overlay
+++ b/samples/drivers/misc/timeaware_gpio/boards/cytvii_b_h_8m_320_cpu_cyt4bfcche_m7_0.overlay
@@ -1,0 +1,19 @@
+tgpio: &tcpwm1_grp0_tgpio {
+	ifx,peri-group = <IFX_PERI_GRP_INST_SEL(1, 0)>;
+	divider-type = <1>;   /* 16-bit divider */
+	divider-sel = <0>;    /* instance #0 */
+	divider-val = <3000>;    /* no division */
+	status = "okay";
+};
+
+&tgpio1_ch0_38 {
+	pinctrl-0 = <&p21_4_tc1_38_tr>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&tgpio1_ch0_18 {
+	pinctrl-0 = <&p0_0_pwm1_18_line_out>;
+    pinctrl-names = "default";
+	status = "okay";
+};

--- a/zephyr-ifx-cycfg/cytvii_b_h_8m_320_cpu/cycfg_qspi_memslot.c
+++ b/zephyr-ifx-cycfg/cytvii_b_h_8m_320_cpu/cycfg_qspi_memslot.c
@@ -1,0 +1,429 @@
+#include "cycfg_qspi_memslot.h"
+
+/* Mode-dependent SMIF config */
+#ifdef SMIF_MODE_HYPERBUS
+cy_stc_smif_hbmem_device_config_t deviceCfg_S26KL512S_SlaveSlot_0 =
+{
+    .xipReadCmd = CY_SMIF_HB_READ_WRAPPED_BURST,
+    .xipWriteCmd = CY_SMIF_HB_WRITE_WRAPPED_BURST,
+    .hbDevType = CY_SMIF_HB_FLASH,
+    .memSize = 0x4000000,   /* 64MB */
+    .dummyCycles = 16,      /* factory default NVCR latency */
+};
+
+cy_stc_smif_mem_config_t S26KL512S_SlaveSlot_0 =
+{
+    /* Determines the slot number where the memory device is placed. */
+    .slaveSelect = CY_SMIF_SLAVE_SELECT_0,
+    /* Flags. */
+#if (CY_IP_MXSMIF_VERSION >= 2)
+    .flags = CY_SMIF_FLAG_SMIF_REV_3 | CY_SMIF_FLAG_MEMORY_MAPPED | CY_SMIF_FLAG_WR_EN | CY_SMIF_FLAG_MERGE_ENABLE,
+#else
+    .flags = CY_SMIF_FLAG_MEMORY_MAPPED | CY_SMIF_FLAG_WR_EN | CY_SMIF_FLAG_MERGE_ENABLE,
+#endif /* CY_IP_MXSMIF_VERSION */
+    /* The data-line selection options for a slave device. */
+    .dataSelect = CY_SMIF_DATA_SEL0,
+    /* The base address the memory slave is mapped to in the PSoC memory map.
+    Valid when the memory-mapped mode is enabled. */
+    .baseAddress = 0x60000000U,
+    /* The size allocated in the PSoC memory map, for the memory slave device.
+    The size is allocated from the base address. Valid when the memory mapped mode is enabled. */
+    .memMappedSize = 0x4000000U,
+    /* If this memory device is one of the devices in the dual quad SPI configuration.
+    Valid when the memory mapped mode is enabled. */
+    .dualQuadSlots = 0,
+    /* The configuration of the device. */
+    .deviceCfg = 0,
+#if (CY_IP_MXSMIF_VERSION >= 2)
+    /** Continous transfer merge timeout.
+     * After this period the memory device is deselected. A later transfer, even from a
+     * continuous address, starts with the overhead phases (command, address, mode, dummy cycles).
+     * This configuration parameter is available for CAT1B devices. */
+    .mergeTimeout = CY_SMIF_MERGE_TIMEOUT_1_CYCLE,
+    .hbdeviceCfg = &deviceCfg_S26KL512S_SlaveSlot_0
+#else
+#error Features used by this file require CY_IP_MXSMIF_VERSION >= 2.
+#endif /* CY_IP_MXSMIF_VERSION */
+};
+
+cy_stc_smif_hbmem_device_config_t deviceCfg_S27KL0641_SlaveSlot_1 =
+{
+    .xipReadCmd = CY_SMIF_HB_READ_WRAPPED_BURST,
+    .xipWriteCmd = CY_SMIF_HB_WRITE_WRAPPED_BURST,
+    .hbDevType = CY_SMIF_HB_SRAM,
+    .memSize = 0x800000,    /* 8MB */
+    .dummyCycles = 12,      /* CR0 default: 6clk x 2(fixed) = 12 */
+};
+
+cy_stc_smif_mem_config_t S27KL0641_SlaveSlot_1 =
+{
+    .slaveSelect = CY_SMIF_SLAVE_SELECT_1,
+#if (CY_IP_MXSMIF_VERSION >= 2)
+    .flags = CY_SMIF_FLAG_MEMORY_MAPPED | CY_SMIF_FLAG_WR_EN,
+#else
+    .flags = CY_SMIF_FLAG_ALL_DISABLED,
+#endif
+    .dataSelect = CY_SMIF_DATA_SEL0,
+    .baseAddress = 0x64000000U,    /* after S26KL512S 64MB region */
+    .memMappedSize = 0x800000U,    /* 8MB */
+    .dualQuadSlots = 0,
+    .deviceCfg = 0,
+#if (CY_IP_MXSMIF_VERSION >= 2)
+    .mergeTimeout = CY_SMIF_MERGE_TIMEOUT_1_CYCLE,
+    .hbdeviceCfg = &deviceCfg_S27KL0641_SlaveSlot_1
+#endif
+};
+
+cy_stc_smif_mem_config_t* smifMemConfigs[CY_SMIF_DEVICE_NUM] = {
+    &S26KL512S_SlaveSlot_0,
+    &S27KL0641_SlaveSlot_1,
+};
+
+cy_stc_smif_config_t SMIF0_config =
+{
+    .mode = (uint32_t)CY_SMIF_NORMAL,
+    .deselectDelay = SMIF0_DESELECT_DELAY,
+    .rxClockSel = CY_SMIF_SEL_INVERTED_SPHB_RWDS_CLK,
+    .blockEvent = (uint32_t)CY_SMIF_BUS_ERROR,
+    .delayTapEnable = CY_SMIF_DELAY_TAP_ENABLE,
+    .delayLineSelect = CY_SMIF_1_NEW_SEL_PER_TAP,
+};
+
+#else /* SMIF_MODE_DUAL_QSPI */
+
+/* Commands for S25FL256S interfaced in Dual QSPI mode */
+cy_stc_smif_mem_cmd_t S25FL256S_readCmd =
+{
+    .command = 0xECU,
+    .cmdWidth = CY_SMIF_WIDTH_SINGLE,
+    .addrWidth = CY_SMIF_WIDTH_QUAD,
+    .mode = 0x01U,
+    .modeWidth = CY_SMIF_WIDTH_QUAD,
+    .dummyCycles = 5U,
+    .dataWidth = CY_SMIF_WIDTH_QUAD,
+#if (CY_IP_MXSMIF_VERSION >= 2)
+    .dataRate = CY_SMIF_SDR,
+    .dummyCyclesPresence = CY_SMIF_PRESENT_1BYTE,
+    .modePresence = CY_SMIF_PRESENT_1BYTE,
+    .modeH = 0x00,
+    .modeRate = CY_SMIF_SDR,
+    .addrRate = CY_SMIF_SDR,
+    .cmdPresence = CY_SMIF_PRESENT_1BYTE,
+    .commandH = 0x00,
+    .cmdRate = CY_SMIF_SDR,
+#endif
+};
+
+cy_stc_smif_mem_cmd_t S25FL256S_writeEnCmd =
+{
+    .command = 0x06U,
+    .cmdWidth = CY_SMIF_WIDTH_SINGLE,
+    .addrWidth = CY_SMIF_WIDTH_SINGLE,
+    .mode = 0xFFFFFFFFU,
+    .modeWidth = CY_SMIF_WIDTH_SINGLE,
+    .dummyCycles = 0U,
+    .dataWidth = CY_SMIF_WIDTH_SINGLE,
+#if (CY_IP_MXSMIF_VERSION >= 2)
+    .dataRate = CY_SMIF_SDR,
+    .dummyCyclesPresence = CY_SMIF_NOT_PRESENT,
+    .modePresence = CY_SMIF_NOT_PRESENT,
+    .modeH = 0x00,
+    .modeRate = CY_SMIF_SDR,
+    .addrRate = CY_SMIF_SDR,
+    .cmdPresence = CY_SMIF_PRESENT_1BYTE,
+    .commandH = 0x00,
+    .cmdRate = CY_SMIF_SDR,
+#endif
+};
+
+cy_stc_smif_mem_cmd_t S25FL256S_writeDisCmd =
+{
+    .command = 0x04U,
+    .cmdWidth = CY_SMIF_WIDTH_SINGLE,
+    .addrWidth = CY_SMIF_WIDTH_SINGLE,
+    .mode = 0xFFFFFFFFU,
+    .modeWidth = CY_SMIF_WIDTH_SINGLE,
+    .dummyCycles = 0U,
+    .dataWidth = CY_SMIF_WIDTH_SINGLE,
+#if (CY_IP_MXSMIF_VERSION >= 2)
+    .dataRate = CY_SMIF_SDR,
+    .dummyCyclesPresence = CY_SMIF_NOT_PRESENT,
+    .modePresence = CY_SMIF_NOT_PRESENT,
+    .modeH = 0x00,
+    .modeRate = CY_SMIF_SDR,
+    .addrRate = CY_SMIF_SDR,
+    .cmdPresence = CY_SMIF_PRESENT_1BYTE,
+    .commandH = 0x00,
+    .cmdRate = CY_SMIF_SDR,
+#endif
+};
+
+cy_stc_smif_mem_cmd_t S25FL256S_eraseCmd =
+{
+    .command = 0xDCU,
+    .cmdWidth = CY_SMIF_WIDTH_SINGLE,
+    .addrWidth = CY_SMIF_WIDTH_SINGLE,
+    .mode = 0xFFFFFFFFU,
+    .modeWidth = CY_SMIF_WIDTH_SINGLE,
+    .dummyCycles = 0U,
+    .dataWidth = CY_SMIF_WIDTH_SINGLE,
+#if (CY_IP_MXSMIF_VERSION >= 2)
+    .dataRate = CY_SMIF_SDR,
+    .dummyCyclesPresence = CY_SMIF_NOT_PRESENT,
+    .modePresence = CY_SMIF_NOT_PRESENT,
+    .modeH = 0x00,
+    .modeRate = CY_SMIF_SDR,
+    .addrRate = CY_SMIF_SDR,
+    .cmdPresence = CY_SMIF_PRESENT_1BYTE,
+    .commandH = 0x00,
+    .cmdRate = CY_SMIF_SDR,
+#endif
+};
+
+cy_stc_smif_mem_cmd_t S25FL256S_chipEraseCmd =
+{
+    .command = 0x60U,
+    .cmdWidth = CY_SMIF_WIDTH_SINGLE,
+    .addrWidth = CY_SMIF_WIDTH_SINGLE,
+    .mode = 0xFFFFFFFFU,
+    .modeWidth = CY_SMIF_WIDTH_SINGLE,
+    .dummyCycles = 0U,
+    .dataWidth = CY_SMIF_WIDTH_SINGLE,
+#if (CY_IP_MXSMIF_VERSION >= 2)
+    .dataRate = CY_SMIF_SDR,
+    .dummyCyclesPresence = CY_SMIF_NOT_PRESENT,
+    .modePresence = CY_SMIF_NOT_PRESENT,
+    .modeH = 0x00,
+    .modeRate = CY_SMIF_SDR,
+    .addrRate = CY_SMIF_SDR,
+    .cmdPresence = CY_SMIF_PRESENT_1BYTE,
+    .commandH = 0x00,
+    .cmdRate = CY_SMIF_SDR,
+#endif
+};
+
+cy_stc_smif_mem_cmd_t S25FL256S_programCmd =
+{
+    .command = 0x34U,
+    .cmdWidth = CY_SMIF_WIDTH_SINGLE,
+    .addrWidth = CY_SMIF_WIDTH_SINGLE,
+    .mode = 0xFFFFFFFFU,
+    .modeWidth = CY_SMIF_WIDTH_SINGLE,
+    .dummyCycles = 0U,
+    .dataWidth = CY_SMIF_WIDTH_QUAD,
+#if (CY_IP_MXSMIF_VERSION >= 2)
+    .dataRate = CY_SMIF_SDR,
+    .dummyCyclesPresence = CY_SMIF_NOT_PRESENT,
+    .modePresence = CY_SMIF_NOT_PRESENT,
+    .modeH = 0x00,
+    .modeRate = CY_SMIF_SDR,
+    .addrRate = CY_SMIF_SDR,
+    .cmdPresence = CY_SMIF_PRESENT_1BYTE,
+    .commandH = 0x00,
+    .cmdRate = CY_SMIF_SDR,
+#endif
+};
+
+cy_stc_smif_mem_cmd_t S25FL256S_readStsRegQeCmd =
+{
+    .command = 0x35U,
+    .cmdWidth = CY_SMIF_WIDTH_SINGLE,
+    .addrWidth = CY_SMIF_WIDTH_SINGLE,
+    .mode = 0xFFFFFFFFU,
+    .modeWidth = CY_SMIF_WIDTH_SINGLE,
+    .dummyCycles = 0U,
+    .dataWidth = CY_SMIF_WIDTH_SINGLE,
+#if (CY_IP_MXSMIF_VERSION >= 2)
+    .dataRate = CY_SMIF_SDR,
+    .dummyCyclesPresence = CY_SMIF_NOT_PRESENT,
+    .modePresence = CY_SMIF_NOT_PRESENT,
+    .modeH = 0x00,
+    .modeRate = CY_SMIF_SDR,
+    .addrRate = CY_SMIF_SDR,
+    .cmdPresence = CY_SMIF_PRESENT_1BYTE,
+    .commandH = 0x00,
+    .cmdRate = CY_SMIF_SDR,
+#endif
+};
+
+cy_stc_smif_mem_cmd_t S25FL256S_readStsRegWipCmd =
+{
+    .command = 0x05U,
+    .cmdWidth = CY_SMIF_WIDTH_SINGLE,
+    .addrWidth = CY_SMIF_WIDTH_SINGLE,
+    .mode = 0xFFFFFFFFU,
+    .modeWidth = CY_SMIF_WIDTH_SINGLE,
+    .dummyCycles = 0U,
+    .dataWidth = CY_SMIF_WIDTH_SINGLE,
+#if (CY_IP_MXSMIF_VERSION >= 2)
+    .dataRate = CY_SMIF_SDR,
+    .dummyCyclesPresence = CY_SMIF_NOT_PRESENT,
+    .modePresence = CY_SMIF_NOT_PRESENT,
+    .modeH = 0x00,
+    .modeRate = CY_SMIF_SDR,
+    .addrRate = CY_SMIF_SDR,
+    .cmdPresence = CY_SMIF_PRESENT_1BYTE,
+    .commandH = 0x00,
+    .cmdRate = CY_SMIF_SDR,
+#endif
+};
+
+cy_stc_smif_mem_cmd_t S25FL256S_writeStsRegQeCmd =
+{
+    .command = 0x01U,
+    .cmdWidth = CY_SMIF_WIDTH_SINGLE,
+    .addrWidth = CY_SMIF_WIDTH_SINGLE,
+    .mode = 0xFFFFFFFFU,
+    .modeWidth = CY_SMIF_WIDTH_SINGLE,
+    .dummyCycles = 0U,
+    .dataWidth = CY_SMIF_WIDTH_SINGLE,
+#if (CY_IP_MXSMIF_VERSION >= 2)
+    .dataRate = CY_SMIF_SDR,
+    .dummyCyclesPresence = CY_SMIF_NOT_PRESENT,
+    .modePresence = CY_SMIF_NOT_PRESENT,
+    .modeH = 0x00,
+    .modeRate = CY_SMIF_SDR,
+    .addrRate = CY_SMIF_SDR,
+    .cmdPresence = CY_SMIF_PRESENT_1BYTE,
+    .commandH = 0x00,
+    .cmdRate = CY_SMIF_SDR,
+#endif
+};
+
+cy_stc_smif_mem_device_cfg_t deviceCfg_S25FL256S_SlaveSlot_0 =
+{
+    .numOfAddrBytes = 0x04U,
+    .memSize = 0x2000000U,      /* 32MB */
+    .readCmd = &S25FL256S_readCmd,
+    .writeEnCmd = &S25FL256S_writeEnCmd,
+    .writeDisCmd = &S25FL256S_writeDisCmd,
+    .eraseCmd = &S25FL256S_eraseCmd,
+    .eraseSize = 0x0040000U,    /* 256KB sectors */
+    .chipEraseCmd = &S25FL256S_chipEraseCmd,
+    .programCmd = &S25FL256S_programCmd,
+    .programSize = 0x0000100U,  /* 256B page */
+    .readStsRegQeCmd = &S25FL256S_readStsRegQeCmd,
+    .readStsRegWipCmd = &S25FL256S_readStsRegWipCmd,
+    .writeStsRegQeCmd = &S25FL256S_writeStsRegQeCmd,
+    .stsRegBusyMask = 0x01U,
+    .stsRegQuadEnableMask = 0x02U,
+    .eraseTime = 2600U,
+    .chipEraseTime = 330000U,
+    .programTime = 750U,
+#if (CY_SMIF_DRV_VERSION_MAJOR > 1) || (CY_SMIF_DRV_VERSION_MINOR >= 50)
+    .hybridRegionCount = 0U,
+    .hybridRegionInfo = 0,
+#endif
+    .readLatencyCmd = 0,
+    .writeLatencyCmd = 0,
+    .latencyCyclesRegAddr = 0x00U,
+    .latencyCyclesMask = 0x00U,
+#if (CY_IP_MXSMIF_VERSION >= 2)
+    .octalDDREnableSeq = 0,
+    .readStsRegOeCmd = 0,
+    .writeStsRegOeCmd = 0,
+    .stsRegOctalEnableMask = 0x00U,
+    .octalEnableRegAddr = 0x00U,
+    .freq_of_operation = CY_SMIF_100MHZ_OPERATION,
+#endif
+};
+
+cy_stc_smif_mem_device_cfg_t deviceCfg_S25FL256S_SlaveSlot_1 =
+{
+    .numOfAddrBytes = 0x04U,
+    .memSize = 0x2000000U,
+    .readCmd = &S25FL256S_readCmd,
+    .writeEnCmd = &S25FL256S_writeEnCmd,
+    .writeDisCmd = &S25FL256S_writeDisCmd,
+    .eraseCmd = &S25FL256S_eraseCmd,
+    .eraseSize = 0x0040000U,
+    .chipEraseCmd = &S25FL256S_chipEraseCmd,
+    .programCmd = &S25FL256S_programCmd,
+    .programSize = 0x0000100U,
+    .readStsRegQeCmd = &S25FL256S_readStsRegQeCmd,
+    .readStsRegWipCmd = &S25FL256S_readStsRegWipCmd,
+    .writeStsRegQeCmd = &S25FL256S_writeStsRegQeCmd,
+    .stsRegBusyMask = 0x01U,
+    .stsRegQuadEnableMask = 0x02U,
+    .eraseTime = 2600U,
+    .chipEraseTime = 330000U,
+    .programTime = 750U,
+#if (CY_SMIF_DRV_VERSION_MAJOR > 1) || (CY_SMIF_DRV_VERSION_MINOR >= 50)
+    .hybridRegionCount = 0U,
+    .hybridRegionInfo = 0,
+#endif
+    .readLatencyCmd = 0,
+    .writeLatencyCmd = 0,
+    .latencyCyclesRegAddr = 0x00U,
+    .latencyCyclesMask = 0x00U,
+#if (CY_IP_MXSMIF_VERSION >= 2)
+    .octalDDREnableSeq = 0,
+    .readStsRegOeCmd = 0,
+    .writeStsRegOeCmd = 0,
+    .stsRegOctalEnableMask = 0x00U,
+    .octalEnableRegAddr = 0x00U,
+    .freq_of_operation = CY_SMIF_100MHZ_OPERATION,
+#endif
+};
+
+/* SEL0: DQ0-DQ3 */
+cy_stc_smif_mem_config_t S25FL256S_SlaveSlot_0 =
+{
+    .slaveSelect = CY_SMIF_SLAVE_SELECT_0,
+#if (CY_IP_MXSMIF_VERSION >= 2)
+    .flags = CY_SMIF_FLAG_MEMORY_MAPPED | CY_SMIF_FLAG_WR_EN,
+#else
+    .flags = CY_SMIF_FLAG_ALL_DISABLED,
+#endif
+    .dataSelect = CY_SMIF_DATA_SEL0,
+    .baseAddress = 0x60000000U,
+    .memMappedSize = 0x2000000U,    /* 32MB */
+    .dualQuadSlots = CY_SMIF_SLAVE_SELECT_0 | CY_SMIF_SLAVE_SELECT_1,
+    .deviceCfg = &deviceCfg_S25FL256S_SlaveSlot_0,
+#if (CY_IP_MXSMIF_VERSION >= 2)
+    .mergeTimeout = CY_SMIF_MERGE_TIMEOUT_1_CYCLE,
+#endif
+};
+
+/* SEL1: DQ4-DQ7 */
+cy_stc_smif_mem_config_t S25FL256S_SlaveSlot_1 =
+{
+    .slaveSelect = CY_SMIF_SLAVE_SELECT_1,
+#if (CY_IP_MXSMIF_VERSION >= 2)
+    .flags = CY_SMIF_FLAG_MEMORY_MAPPED | CY_SMIF_FLAG_WR_EN,
+#else
+    .flags = CY_SMIF_FLAG_ALL_DISABLED,
+#endif
+    .dataSelect = CY_SMIF_DATA_SEL2,
+    .baseAddress = 0x62000000U,
+    .memMappedSize = 0x2000000U,    /* 32MB */
+    .dualQuadSlots = CY_SMIF_SLAVE_SELECT_0 | CY_SMIF_SLAVE_SELECT_1,
+    .deviceCfg = &deviceCfg_S25FL256S_SlaveSlot_1,
+#if (CY_IP_MXSMIF_VERSION >= 2)
+    .mergeTimeout = CY_SMIF_MERGE_TIMEOUT_1_CYCLE,
+#endif
+};
+
+cy_stc_smif_mem_config_t* smifMemConfigs[CY_SMIF_DEVICE_NUM] = {
+    &S25FL256S_SlaveSlot_0,
+    &S25FL256S_SlaveSlot_1,
+};
+
+cy_stc_smif_config_t SMIF0_config =
+{
+    .mode = (uint32_t)CY_SMIF_NORMAL,
+    .deselectDelay = SMIF0_DESELECT_DELAY,
+    .rxClockSel = CY_SMIF_SEL_INVERTED_FEEDBACK_CLK,
+    .blockEvent = (uint32_t)CY_SMIF_BUS_ERROR,
+    .delayTapEnable = CY_SMIF_DELAY_TAP_DISABLE,
+    .delayLineSelect = CY_SMIF_NO_DELAY_SEL,
+};
+#endif
+
+cy_stc_smif_block_config_t smif0BlockConfig =
+{
+    .memCount = CY_SMIF_DEVICE_NUM,
+    .memConfig = (cy_stc_smif_mem_config_t**)smifMemConfigs,
+    .majorVersion = CY_SMIF_DRV_VERSION_MAJOR,
+    .minorVersion = CY_SMIF_DRV_VERSION_MINOR,
+};

--- a/zephyr-ifx-cycfg/cytvii_b_h_8m_320_cpu/cycfg_qspi_memslot.h
+++ b/zephyr-ifx-cycfg/cytvii_b_h_8m_320_cpu/cycfg_qspi_memslot.h
@@ -1,0 +1,54 @@
+#ifndef CYCFG_QSPI_MEMSLOT_H
+#define CYCFG_QSPI_MEMSLOT_H
+#include "cy_smif_memslot.h"
+
+#define CY_SMIF_CFG_TOOL_VERSION           (460)
+
+#define CY_SMIF_DRV_VERSION_REQUIRED       (100)
+
+#if !defined(CY_SMIF_DRV_VERSION)
+    #define CY_SMIF_DRV_VERSION            (100)
+#endif
+
+#if (CY_SMIF_DRV_VERSION_REQUIRED > CY_SMIF_DRV_VERSION)
+   #error The QSPI Configurator requires a newer version of the PDL.
+#endif
+
+typedef cy_stc_smif_mem_config_t cy_serial_flash_mem_config_t;
+typedef cy_stc_smif_block_config_t cy_serial_flash_block_config_t;
+
+#define CY_SMIF_DEVICE_NUM 2
+
+#define SMIF0_DESELECT_DELAY 7
+
+#ifdef SMIF_MODE_HYPERBUS /* HyperBus devices */
+extern cy_stc_smif_hbmem_device_config_t deviceCfg_S26KL512S_SlaveSlot_0;
+extern cy_stc_smif_mem_config_t S26KL512S_SlaveSlot_0;
+
+extern cy_stc_smif_hbmem_device_config_t deviceCfg_S27KL0641_SlaveSlot_1;
+extern cy_stc_smif_mem_config_t S27KL0641_SlaveSlot_1;
+
+#else /* Dual QSPI devices */
+
+extern cy_stc_smif_mem_cmd_t S25FL256S_readCmd;
+extern cy_stc_smif_mem_cmd_t S25FL256S_writeEnCmd;
+extern cy_stc_smif_mem_cmd_t S25FL256S_writeDisCmd;
+extern cy_stc_smif_mem_cmd_t S25FL256S_eraseCmd;
+extern cy_stc_smif_mem_cmd_t S25FL256S_chipEraseCmd;
+extern cy_stc_smif_mem_cmd_t S25FL256S_programCmd;
+extern cy_stc_smif_mem_cmd_t S25FL256S_readStsRegQeCmd;
+extern cy_stc_smif_mem_cmd_t S25FL256S_readStsRegWipCmd;
+extern cy_stc_smif_mem_cmd_t S25FL256S_writeStsRegQeCmd;
+
+extern cy_stc_smif_mem_device_cfg_t deviceCfg_S25FL256S_SlaveSlot_0;
+extern cy_stc_smif_mem_config_t S25FL256S_SlaveSlot_0;
+
+extern cy_stc_smif_mem_device_cfg_t deviceCfg_S25FL256S_SlaveSlot_1;
+extern cy_stc_smif_mem_config_t S25FL256S_SlaveSlot_1;
+#endif
+
+extern cy_stc_smif_mem_config_t* smifMemConfigs[CY_SMIF_DEVICE_NUM];
+extern cy_stc_smif_block_config_t smif0BlockConfig;
+extern cy_stc_smif_config_t SMIF0_config;
+
+#endif /* CYCFG_QSPI_MEMSLOT_H */


### PR DESCRIPTION

1. Added ADC node for potentiometer configuration.
2. Added PWM nodes and pinctrl for cytvii_b_h_8m_320_cpu.
3. Added overlay for Flash, tgpio, counter and PWM.
4. Tested following modules on cytvii_b_h_8m_320_cpu.

| Module     | Test Status | Test Results |
|------------|-------------|--------------|
| Blinky      | Tested      | PASS ✅      |
| Button     | Tested      | PASS ✅      |
| GPIO       | Tested      | PASS ✅      |
| UART       | Tested      | PASS ✅      |
| SPI        | Tested      | PASS ✅      |
| ADC        | Tested      | PASS ✅      |
| CAN        | Tested      | PASS ✅      |
| Watchdog   | Tested      | PASS ✅      |
| PWM        | Tested      | PASS ✅      |
| TGPIO      | Tested      | PASS ✅      |
| Counter    | Tested      | PASS ✅      |
| IPC        | Tested      | FAIL ❌      |
| DMA        | Tested      | PASS ✅      |
| HWINFO     | Tested      | PASS ✅      |
| SROM API   | Tested      | PASS ✅      |
