### PR TITLE
boards: infineon: kit_t2g-b-h_lite: Fix LED polarity to ACTIVE_LOW

### DIFF
--- a/boards/infineon/kit_t2g-b-h_lite/kit_t2g-b-h_lite_common.dtsi
+++ b/boards/infineon/kit_t2g-b-h_lite/kit_t2g-b-h_lite_common.dtsi
@@ -35,15 +35,15 @@
 		compatible = "gpio-leds";
 		user_led1: user_led1 {
 			label = "LED_1";
-			gpios = <&gpio_prt5 0 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio_prt5 0 GPIO_ACTIVE_LOW>;
 		};
 		user_led2: user_led2 {
 			label = "LED_2";
-			gpios = <&gpio_prt5 1 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio_prt5 1 GPIO_ACTIVE_LOW>;
 		};
 		user_led3: user_led3 {
 			label = "LED_3";
-			gpios = <&gpio_prt5 2 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio_prt5 2 GPIO_ACTIVE_LOW>;
 		};
 	};
 


### PR DESCRIPTION
User LEDs on the kit_t2g-b-h_lite are active LOW (grounded to turn ON), but were incorrectly declared as GPIO_ACTIVE_HIGH. Fix all three user LEDs to GPIO_ACTIVE_LOW to match hardware behavior per the board user manual.

Fixes #322 .