### PR TITLE
boards: infineon: kit_t2g-b-h_lite: Fix CAN pinctrl channel, port and and HSIOM

### DIFF
--- a/boards/infineon/kit_t2g-b-h_lite/kit_t2g-b-h_lite_common.dtsi
+++ b/boards/infineon/kit_t2g-b-h_lite/kit_t2g-b-h_lite_common.dtsi
@@ -129,12 +129,12 @@ uart0: &scb0 {
 };
 
 &pinctrl {
-	/omit-if-no-ref/ p12_0_can0_0_tx: p12_0_can0_0_tx {
-		pinmux = <DT_CAT1_PINMUX(5, 0, HSIOM_SEL_ACT_13)>;
+	/omit-if-no-ref/ p12_0_can0_2_tx: p12_0_can0_2_tx {
+		pinmux = <DT_CAT1_PINMUX(12, 0, HSIOM_SEL_ACT_9)>;
 		drive-push-pull;
 	};
-	/omit-if-no-ref/ p12_1_can0_0_rx: p12_1_can0_0_rx {
-		pinmux = <DT_CAT1_PINMUX(5, 1, HSIOM_SEL_ACT_13)>;
+	/omit-if-no-ref/ p12_1_can0_2_rx: p12_1_can0_2_rx {
+		pinmux = <DT_CAT1_PINMUX(12, 1, HSIOM_SEL_ACT_9)>;
 		input-enable;
 	};
 
@@ -191,17 +191,17 @@ uart0: &scb0 {
 	};
 };
 
-can0: &can0_0 {
+can0: &can0_2 {
 	compatible = "infineon,cat1-can";
 	clocks = <&clk_hf2>;
 	clock-frequency = <40000000>;
 	ifx,peri-group = <IFX_PERI_GRP_INST_SEL(1, 0)>;
-	ifx,peri-clk = <0x0100>;
+	ifx,peri-clk = <0x0102>;
 	ifx,peri-div = <3>; /* 24-bit divider */
 	ifx,peri-div-inst = <0>;
-
-	pinctrl-0 = <&p12_0_can0_0_tx &p12_1_can0_0_rx>;
+	pinctrl-0 = <&p12_0_can0_2_tx &p12_1_can0_2_rx>;
 	pinctrl-names = "default";
+	status = "okay";
 };
 
 spi1: &scb3 {

--- a/boards/infineon/kit_t2g-b-h_lite/kit_t2g-b-h_lite_pinctrl.dtsi
+++ b/boards/infineon/kit_t2g-b-h_lite/kit_t2g-b-h_lite_pinctrl.dtsi
@@ -9,12 +9,12 @@
 #include <zephyr/dt-bindings/pwm/pwm.h>
 
 &pinctrl {
-	/omit-if-no-ref/ p12_0_can0_0_tx: p12_0_can0_0_tx {
-		pinmux = <DT_CAT1_PINMUX(5, 0, HSIOM_SEL_ACT_13)>;
+	/omit-if-no-ref/ p12_0_can0_2_tx: p12_0_can0_2_tx {
+		pinmux = <DT_CAT1_PINMUX(12, 0, HSIOM_SEL_ACT_9)>;
 		drive-push-pull;
 	};
-	/omit-if-no-ref/ p12_1_can0_0_rx: p12_1_can0_0_rx {
-		pinmux = <DT_CAT1_PINMUX(5, 1, HSIOM_SEL_ACT_13)>;
+	/omit-if-no-ref/ p12_1_can0_2_rx: p12_1_can0_2_rx {
+		pinmux = <DT_CAT1_PINMUX(12, 1, HSIOM_SEL_ACT_9)>;
 		input-enable;
 	};
 


### PR DESCRIPTION
The CAN configuration for kit_t2g-b-h_lite had three errors:

1. Wrong channel: can0_0 → can0_2
   P12.0/P12.1 (J5 CAN transceiver) only support CANFD0 channel 2.

2. Wrong port: DT_CAT1_PINMUX(5, ...) → DT_CAT1_PINMUX(12, ...)
   Port 5 pins (P5.0/P5.1) are the LED pins, not the CAN transceiver.

3. Wrong HSIOM: HSIOM_SEL_ACT_13 → HSIOM_SEL_ACT_9
   ACT_13 maps to AUDIOSS0_TX_SDO. The correct function for
   CANFD0_TTCAN_TX2/RX2 on P12.0/P12.1 is ACT_9.

Also update ifx,peri-clk from 0x0100 to 0x0102 for channel 2.

Fixes #324 .